### PR TITLE
Fix and refator detection of tools

### DIFF
--- a/org.eclipse.cdt.cross.arc.gnu.uclibc/src/org/eclipse/cdt/cross/arc/gnu/uclibc/common/CommandInfo.java
+++ b/org.eclipse.cdt.cross.arc.gnu.uclibc/src/org/eclipse/cdt/cross/arc/gnu/uclibc/common/CommandInfo.java
@@ -43,9 +43,8 @@ public class CommandInfo {
     
     private static String normalizeCommand(String cmd) {
         // There may be arguments so only grab up to the whitespace
-        if (cmd.indexOf(' ') > 0) {
+        if (cmd.indexOf(' ') > 0)
             cmd = cmd.substring(0, cmd.indexOf(' '));
-        }
         if (isWindows() && !cmd.toLowerCase().endsWith(".exe"))
             cmd = cmd + ".exe";
         return cmd;
@@ -59,9 +58,8 @@ public class CommandInfo {
         if (path != null) {
             String paths[] = path.split(File.pathSeparator);
             for (String p : paths) {
-                if (new File(p, cmd).isFile()) {
+                if (new File(p, cmd).isFile())
                     return true;
-                }
             }
         }
         
@@ -83,7 +81,7 @@ public class CommandInfo {
      * Determine whether or not we're running on Microsoft Windows.
      * @return true if we're running under Microsoft Windows.
      */
-    public static boolean isWindows(){
+    public static boolean isWindows() {
         return System.getProperty("os.name").indexOf("indow") > 0;
     }
 

--- a/org.eclipse.cdt.cross.arc.gnu.uclibc/src/org/eclipse/cdt/cross/arc/gnu/uclibc/common/CommandInfo.java
+++ b/org.eclipse.cdt.cross.arc.gnu.uclibc/src/org/eclipse/cdt/cross/arc/gnu/uclibc/common/CommandInfo.java
@@ -31,39 +31,52 @@ public class CommandInfo {
      * @param cmd the command
      * @return whether or not a command exists.
      */
-    public static boolean commandExists (String cmd) {
+    public static boolean commandExists(String cmd) {
+        cmd = normalizeCommand(cmd);
+        
+        File f = new File(cmd);
+        if (f.isAbsolute())
+            return f.exists();
+        
+        return commandExistsInSystemPath(cmd) || commandExistsInPredefinedPath(cmd);
+    }
+    
+    private static String normalizeCommand(String cmd) {
         // There may be arguments so only grab up to the whitespace
         if (cmd.indexOf(' ') > 0) {
             cmd = cmd.substring(0, cmd.indexOf(' '));
         }
         if (isWindows() && !cmd.toLowerCase().endsWith(".exe"))
             cmd = cmd + ".exe";
-        File f = new File(cmd);
-        if (f.isAbsolute())
-            return f.exists();
-        //Checking for compiler presence in PATH,
+        return cmd;
+    }
+    
+    public static boolean commandExistsInSystemPath(String cmd) {
+        cmd = normalizeCommand(cmd);
+        
+        // Checking for compiler presence in PATH.
         String path = System.getenv("PATH");
-        if (path == null)
-            return true; // punt
-
-  
-        String paths[] = path.split(File.pathSeparator);
-        for (String p : paths) {
-            if (new File(p, cmd).isFile()){
-                return true;	
-            }            	
+        if (path != null) {
+            String paths[] = path.split(File.pathSeparator);
+            for (String p : paths) {
+                if (new File(p, cmd).isFile()) {
+                    return true;
+                }
+            }
         }
         
-        	// Checking for compiler presence in location ../bin? Relative to eclipse.exe.
-            // So IDE releases will work even when PATH is not configured
-            String eclipsehome = Platform.getInstallLocation().getURL().getPath();
-    		File predefined_path_dir = new File(eclipsehome).getParentFile();
-            String predefined_path = predefined_path_dir + File.separator + "bin";
-            if (new File(predefined_path, cmd).isFile()){
-                return true;
-            }
-        
         return false;
+    }
+    
+    public static boolean commandExistsInPredefinedPath(String cmd) {
+        cmd = normalizeCommand(cmd);
+        
+        // Checking for compiler presence in location ../bin relative to eclipse.exe.
+        // So IDE releases will work even when PATH is not configured
+        String eclipsehome = Platform.getInstallLocation().getURL().getPath();
+        File predefined_path_dir = new File(eclipsehome).getParentFile();
+        String predefined_path = predefined_path_dir + File.separator + "bin";
+        return new File(predefined_path, cmd).isFile();
     }
     
     /**

--- a/org.eclipse.cdt.cross.arc.gnu.uclibc/src/org/eclipse/cdt/cross/arc/gnu/uclibc/common/IsToolChainSupported.java
+++ b/org.eclipse.cdt.cross.arc.gnu.uclibc/src/org/eclipse/cdt/cross/arc/gnu/uclibc/common/IsToolChainSupported.java
@@ -1,6 +1,16 @@
-/*    */ package org.eclipse.cdt.cross.arc.gnu.uclibc.common;
-/*    */ 
-/*    */ import java.io.File;
+/*******************************************************************************
+ * This program and the accompanying materials 
+ * are made available under the terms of the Common Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/cpl-v10.html
+ * 
+ * Contributors:
+ *     Synopsys, Inc. - ARC GNU Toolchain support
+ *******************************************************************************/
+
+package org.eclipse.cdt.cross.arc.gnu.uclibc.common;
+
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
@@ -12,45 +22,48 @@ import org.eclipse.cdt.managedbuilder.core.IToolChain;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Version;
 
-public abstract class IsToolChainSupported implements IManagedIsToolChainSupported
-{
-   static final boolean DEBUG = false;
+public abstract class IsToolChainSupported implements
+        IManagedIsToolChainSupported {
+    static final boolean DEBUG = false;
 
-   public String getCompilerName()
-  {
-     return "arc-linux-gcc";
-  }
+    public String getCompilerName() {
+        return "arc-linux-gcc";
+    }
 
-   public String getPlatform() {
-     return "linux";
-   }
+    public String getPlatform() {
+        return "linux";
+    }
 
-public boolean isSupportedImpl(IToolChain oToolChain, Version oVersion, String sInstance, IsToolchainData oStaticData)
-{
-	ITool[] tools = oToolChain.getTools();
-    for (ITool tool : tools) {
-        String extensions[] = tool.getAllOutputExtensions();
-        List<String> extList = Arrays.asList(extensions);
-        if (extList.contains("o") || extList.contains("obj")) {
-            // We assume this tool is the compiler if its output
-            // is .o or .obj file.
-            // If the compiler doesn't exist in the search path,
-            // then we don't support the tool.
-            String cmd = tool.getToolCommand();
-            if (cmd != null && cmd.length() > 0) {
-                if (!CommandInfo.commandExists(cmd))
-                    return false;
+    public boolean isSupportedImpl(IToolChain oToolChain, Version oVersion,
+            String sInstance, IsToolchainData oStaticData) {
+        ITool[] tools = oToolChain.getTools();
+        for (ITool tool : tools) {
+            String extensions[] = tool.getAllOutputExtensions();
+            List<String> extList = Arrays.asList(extensions);
+            if (extList.contains("o") || extList.contains("obj")) {
+                // We assume this tool is the compiler if its output
+                // is .o or .obj file.
+                // If the compiler doesn't exist in the search path,
+                // then we don't support the tool.
+                String cmd = tool.getToolCommand();
+                if (cmd != null && cmd.length() > 0) {
+                    if (!CommandInfo.commandExists(cmd))
+                        return false;
+                }
+            }
+
+            String current_tool_command = tool.getToolCommand();
+            if (CommandInfo.commandExistsInPredefinedPath(current_tool_command)) {
+                String eclipsehome = Platform.getInstallLocation().getURL().getPath();
+                File predefined_path_dir = new File(eclipsehome).getParentFile();
+                String predefined_path = predefined_path_dir + File.separator
+                        + "bin" + File.separator;
+                if (current_tool_command.indexOf(predefined_path) < 0) {
+                    tool.setToolCommand(predefined_path + current_tool_command);
+                }
             }
         }
 
-        String current_tool_command=tool.getToolCommand();
-        String eclipsehome = Platform.getInstallLocation().getURL().getPath();
-        File predefined_path_dir = new File(eclipsehome).getParentFile();
-        String predefined_path = predefined_path_dir + File.separator + "bin"+File.separator;
-        if(current_tool_command.indexOf(predefined_path)<0){
-            tool.setToolCommand(predefined_path + current_tool_command); 
-        }  
+        return true;
     }
-    return true;
-}
 }

--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/CommandInfo.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/CommandInfo.java
@@ -43,9 +43,8 @@ public class CommandInfo {
     
     private static String normalizeCommand(String cmd) {
         // There may be arguments so only grab up to the whitespace
-        if (cmd.indexOf(' ') > 0) {
+        if (cmd.indexOf(' ') > 0)
             cmd = cmd.substring(0, cmd.indexOf(' '));
-        }
         if (isWindows() && !cmd.toLowerCase().endsWith(".exe"))
             cmd = cmd + ".exe";
         return cmd;
@@ -59,9 +58,8 @@ public class CommandInfo {
         if (path != null) {
             String paths[] = path.split(File.pathSeparator);
             for (String p : paths) {
-                if (new File(p, cmd).isFile()) {
+                if (new File(p, cmd).isFile())
                     return true;
-                }
             }
         }
         
@@ -83,7 +81,7 @@ public class CommandInfo {
      * Determine whether or not we're running on Microsoft Windows.
      * @return true if we're running under Microsoft Windows.
      */
-    public static boolean isWindows(){
+    public static boolean isWindows() {
         return System.getProperty("os.name").indexOf("indow") > 0;
     }
 

--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/IsToolChainSupported.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/IsToolChainSupported.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
-* This program and the accompanying materials 
-* are made available under the terms of the Common Public License v1.0
-* which accompanies this distribution, and is available at
-* http://www.eclipse.org/legal/cpl-v10.html
-* 
-* Contributors:
-*     Synopsys, Inc. - ARC GNU Toolchain support
-*******************************************************************************/
- 
+ * This program and the accompanying materials 
+ * are made available under the terms of the Common Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/cpl-v10.html
+ * 
+ * Contributors:
+ *     Synopsys, Inc. - ARC GNU Toolchain support
+ *******************************************************************************/
+
 package org.eclipse.cdt.cross.arc.gnu.common;
- 
- import java.io.File;
+
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
@@ -19,52 +19,49 @@ import org.eclipse.cdt.managedbuilder.core.ITool;
 import org.eclipse.cdt.managedbuilder.core.IToolChain;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Version;
- 
- public abstract class IsToolChainSupported
-   implements IManagedIsToolChainSupported
- {
-   static final boolean DEBUG = false;
-  
-   public String getCompilerName()
-   {
-     return "arc-elf32-gcc";
-   }
- 
-   public String getPlatform() {
-     return "linux";
-   }
 
-   public boolean isSupportedImpl(IToolChain oToolChain, Version oVersion, String sInstance, IsToolchainData oStaticData)
-   {
-  
-	   ITool[] tools = oToolChain.getTools();
-       for (ITool tool : tools) {
-    	  
-           String extensions[] = tool.getAllOutputExtensions();
-           List<String> extList = Arrays.asList(extensions);
-           if (extList.contains("o") || extList.contains("obj")) {
-               // We assume this tool is the compiler if its output
-               // is .o or .obj file.
-               // If the compiler doesn't exist in the search path,
-               // then we don't support the tool.
-               String cmd = tool.getToolCommand();
-               if (cmd != null && cmd.length() > 0) {
-                   if (!CommandInfo.commandExists(cmd))
-                       return false;
-               }
-           }
-           
-           String current_tool_command = tool.getToolCommand();
-           String eclipsehome = Platform.getInstallLocation().getURL().getPath();
-           File predefined_path_dir = new File(eclipsehome).getParentFile();
-           String predefined_path = predefined_path_dir + File.separator +
-                   "bin" + File.separator;
-           if(current_tool_command.indexOf(predefined_path)<0){
-               tool.setToolCommand(predefined_path + current_tool_command);
-           }
-       }
-       return true;
-   }
- }
+public abstract class IsToolChainSupported implements
+        IManagedIsToolChainSupported {
+    static final boolean DEBUG = false;
 
+    public String getCompilerName() {
+        return "arc-elf32-gcc";
+    }
 
+    public String getPlatform() {
+        return "linux";
+    }
+
+    public boolean isSupportedImpl(IToolChain oToolChain, Version oVersion,
+            String sInstance, IsToolchainData oStaticData) {
+        ITool[] tools = oToolChain.getTools();
+        for (ITool tool : tools) {
+            String extensions[] = tool.getAllOutputExtensions();
+            List<String> extList = Arrays.asList(extensions);
+            if (extList.contains("o") || extList.contains("obj")) {
+                // We assume this tool is the compiler if its output
+                // is .o or .obj file.
+                // If the compiler doesn't exist in the search path,
+                // then we don't support the tool.
+                String cmd = tool.getToolCommand();
+                if (cmd != null && cmd.length() > 0) {
+                    if (!CommandInfo.commandExists(cmd))
+                        return false;
+                }
+            }
+
+            String current_tool_command = tool.getToolCommand();
+            if (CommandInfo.commandExistsInPredefinedPath(current_tool_command)) {
+                String eclipsehome = Platform.getInstallLocation().getURL().getPath();
+                File predefined_path_dir = new File(eclipsehome).getParentFile();
+                String predefined_path = predefined_path_dir + File.separator
+                        + "bin" + File.separator;
+                if (current_tool_command.indexOf(predefined_path) < 0) {
+                    tool.setToolCommand(predefined_path + current_tool_command);
+                }
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This Pull Request fixes an issue https://github.com/foss-for-synopsys-dwc-arc-processors/arc_gnu_eclipse/issues/3.

Originally there was a bug - Eclipse always tries to use tools from predefined path (`../bin` relatively to the Eclipse) without looking into `PATH` environment variable. I've introduced a method `CommandInfo.commandExistsInPredefinedPath` which helps to check whether tool exists in the predefined path or not. `IsToolChainSupported` uses this method to decide whether to append the predefined path to to the command or not.

Also refactoring and decomposition of `CommandInfo` class is performed.

Actually these classes (and a lot of other classes too) may be unified and placed in the separate plugin which would be common dependency for ELF32 and uClibc plugins. But now it's beyond the scope of this Pull Request.