### PR TITLE
Fix checking a predefined path with OpenOCD binary

### DIFF
--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGDBDebuggerPage.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGDBDebuggerPage.java
@@ -71,7 +71,7 @@ public class RemoteGDBDebuggerPage extends GDBDebuggerPage {
         } else {
             String predefined_path = getIDEBinDir();
             // Checking for OpenOCD binary presence in default path
-            if (new File(predefined_path).isFile()) {
+            if (new File(predefined_path).isDirectory()) {
                 default_oocd_bin = predefined_path + "openocd";
                 default_oocd_cfg = getIDERootDir() + "share/openocd/scripts/board/snps_em_sk.cfg";
             } else {


### PR DESCRIPTION
Variable "pedefined_path" must be checked as a directory.

Signed-off-by: Yuriy Kolerov <yuriy.kolerov@synopsys.com>