### PR TITLE
Escape whitespace characters when reading TCF

### DIFF
--- a/org.eclipse.cdt.cross.arc.gnu/src/com/arc/cdt/toolchain/tcf/TcfContent.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/com/arc/cdt/toolchain/tcf/TcfContent.java
@@ -162,6 +162,14 @@ public class TcfContent {
                 String data = getCharacterDataFromElement((Element) stringList.item(0));
                 if (elementName.equals(GCC_OPTIONS_SECTION)) {
                     tcfContent.gccOptions = new Properties();
+                    /*
+                     * Need to escape whitespaces here because in java.util.Properties key termination
+                     * characters are '=', ':' and whitespace. So if our TCF has several option like
+                     * "--param ...", --param will be considered a key and therefore Properties will
+                     * load only one of these options. If we escape a whitespace, it will be considered
+                     * part of a key.
+                     */
+                    data = data.replace(" ", "\\ ");
                     tcfContent.gccOptions.load(new StringReader(data));
                     tcfContent.checkArchitecture(cpu);
                 }


### PR DESCRIPTION
Compiler options from TCF are read using java.util.Properties, which
consideres '=', ':' and whitespace characters as key termination
characters. So if our TCF contains options like '--param ', --param is
considered a key here and therefore only one of these options can be
read.

But if a whitespace is escaped, it is seen as part of the key and all
the --param options can be read.

Signed-off-by: Anna Pologova <anna.pologova@synopsys.com>