### PR TITLE
Rename ABI, FPU and multiplier options for uclibc

### DIFF
--- a/org.eclipse.cdt.cross.arc.gnu.uclibc/plugin.xml
+++ b/org.eclipse.cdt.cross.arc.gnu.uclibc/plugin.xml
@@ -351,53 +351,28 @@
                   command="-mmpy-option=0"
                   id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.0"
                   isDefault="false"
-                  name="None">
-            </enumeratedOptionValue>
-            <enumeratedOptionValue
-                  command="-mmpy-option=1"
-                  id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.1"
-                  name="1 - 16x16 multiplier, fully pipelined">
+                  name="none">
             </enumeratedOptionValue>
             <enumeratedOptionValue
                   command="-mmpy-option=2"
                   id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.2"
                   isDefault="true"
-                  name="2 - 32x32 multiplier, fully pipelined (1 stage)">
-            </enumeratedOptionValue>
-            <enumeratedOptionValue
-                  command="-mmpy-option=3"
-                  id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.3"
-                  name="3 - 32x32 multiplier, fully pipelined (2 stages)">
-            </enumeratedOptionValue>
-            <enumeratedOptionValue
-                  command="-mmpy-option=4"
-                  id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.4"
-                  name="4 - 2 16x16 multipliers, blocking, sequential">
-            </enumeratedOptionValue>
-            <enumeratedOptionValue
-                  command="-mmpy-option=5"
-                  id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.5"
-                  name="5 - 16x16 multiplier, blocking, sequential">
-            </enumeratedOptionValue>
-            <enumeratedOptionValue
-                  command="-mmpy-option=6"
-                  id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.6"
-                  name="6 - 32x4 multiplier, blocking, sequential">
+                  name="mpy">
             </enumeratedOptionValue>
             <enumeratedOptionValue
                   command="-mmpy-option=7"
                   id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.7"
-                  name="7 - Short vector instructions (32bits)">
+                  name="plus_dmpy">
             </enumeratedOptionValue>
             <enumeratedOptionValue
                   command="-mmpy-option=8"
                   id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.8"
-                  name="8 - Double MAC instructions">
+                  name="plus_macd">
             </enumeratedOptionValue>
             <enumeratedOptionValue
                   command="-mmpy-option=9"
                   id="org.eclipse.cdt.cross.arc.gnu.base.option.mpy.9"
-                  name="9 - 64bit operations">
+                  name="plus_qmacw">
             </enumeratedOptionValue>
          </option>
          <option
@@ -431,7 +406,7 @@
          <option
                applicabilityCalculator="com.arc.cdt.toolchain.arc.ArcApplicabilityCalculator"
                id="org.eclipse.cdt.cross.arc.gnu.uclibc.base.option.target.fpuhs"
-               name="FPU HS Type"
+               name="FPU Type (ARC HS)"
                valueType="enumerated">
             <enumeratedOptionValue
                   id="org.eclipse.cdt.cross.arc.gnu.base.option.fpu.none"
@@ -584,12 +559,12 @@
                   command="-mabi=std"
                   id="org.eclipse.cdt.cross.arc.gnu.uclibc.base.option.target.abiselection.std"
                   isDefault="true"
-                  name="Standard ABI (-mabi=std)">
+                  name="Standard GNU ABI (-mabi=std)">
             </enumeratedOptionValue>
             <enumeratedOptionValue
                   command="-mabi=mwabi"
                   id="org.eclipse.cdt.cross.arc.gnu.uclibc.base.option.target.abiselection.mwabi"
-                  name="MW-compatible ABI (-mabi=mwabi)">
+                  name="MetaWare ABI (-mabi=mwabi)">
             </enumeratedOptionValue>
          </option>
       </tool>
@@ -2810,7 +2785,7 @@
                category="org.eclipse.cdt.cross.arc.gnu.hs.uclibc.linux.category.target"
                id="org.eclipse.cdt.cross.arc.gnu.hs.uclibc.linux.option.target.fpuhs"
                isAbstract="false"
-               name="FPU HS Type"
+               name="FPU Type (ARC HS)"
                superClass="org.eclipse.cdt.cross.arc.gnu.uclibc.base.option.target.fpuhs">
          </option>
          <option


### PR DESCRIPTION
These options were renamed for Elf32 plugin, but not Uclibc. This commit
changes these options names so they would be the same in both plugins.

Signed-off-by: Anna Pologova <anna.pologova@synopsys.com>