### PR TITLE
Search for toolchain first in PATH, then in ../bin

### DIFF
--- a/org.eclipse.cdt.cross.arc.gnu.uclibc/src/org/eclipse/cdt/cross/arc/gnu/uclibc/common/IsToolChainSupported.java
+++ b/org.eclipse.cdt.cross.arc.gnu.uclibc/src/org/eclipse/cdt/cross/arc/gnu/uclibc/common/IsToolChainSupported.java
@@ -54,7 +54,10 @@ public abstract class IsToolChainSupported implements
             }
 
             String current_tool_command = tool.getToolCommand();
-            if (CommandInfo.commandExistsInPredefinedPath(current_tool_command)) {
+            // If command is present in both PATH and ../bin, do nothing (use tool from PATH). If it
+            // is present only in ../bin, change command name to path/to/command/command_name.
+            if (CommandInfo.commandExistsInPredefinedPath(current_tool_command)
+                    && !CommandInfo.commandExistsInSystemPath(current_tool_command)) {
                 String eclipsehome = Platform.getInstallLocation().getURL().getPath();
                 File predefined_path_dir = new File(eclipsehome).getParentFile();
                 String predefined_path = predefined_path_dir + File.separator

--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/IsToolChainSupported.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/IsToolChainSupported.java
@@ -51,7 +51,10 @@ public abstract class IsToolChainSupported implements
             }
 
             String current_tool_command = tool.getToolCommand();
-            if (CommandInfo.commandExistsInPredefinedPath(current_tool_command)) {
+            // If command is present in both PATH and ../bin, do nothing (use tool from PATH). If it
+            // is present only in ../bin, change command name to path/to/command/command_name.
+            if (CommandInfo.commandExistsInPredefinedPath(current_tool_command)
+                    && !CommandInfo.commandExistsInSystemPath(current_tool_command)) {
                 String eclipsehome = Platform.getInstallLocation().getURL().getPath();
                 File predefined_path_dir = new File(eclipsehome).getParentFile();
                 String predefined_path = predefined_path_dir + File.separator


### PR DESCRIPTION
If toolchain for a project is present in both PATH and ../bin directory,
toolchain from ../bin was chosen when creating a new project. But specs
provider in this case was used from toolchain contained in PATH.

To make toolchain choosing consistent, now toolchain from PATH is
selected in both these cases.

Signed-off-by: Anna Pologova <anna.pologova@synopsys.com>