### PR TITLE
Add plug-in versions checking, show warning messages if there are incompatibility issues

### DIFF
--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/LaunchConfigurationConstants.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/LaunchConfigurationConstants.java
@@ -25,6 +25,7 @@ public interface LaunchConfigurationConstants {
             + ".debugger_build_before_launch";
     static final boolean ATTR_DEBUGGER_BUILD_BEFORE_LAUNCH_DEFAULT = true;
 
+    String ATTR_DEBUGGER_PLUGIN_VERSION = LAUNCH_ID + ".debugger_plugin_version";
     String ATTR_DEBUGGER_COMMANDS_INIT = LAUNCH_ID + ".debugger_init_commands"; //$NON-NLS-1$
     String ATTR_DEBUGGER_COMMANDS_RUN = LAUNCH_ID + ".debugger_run_commands"; //$NON-NLS-1$
     String ATTR_DEBUGGER_COMMANDS_LAUNCH = LAUNCH_ID + ".debugger_lauch_commands"; //$NON-NLS-1$
@@ -57,6 +58,11 @@ public interface LaunchConfigurationConstants {
     String ATTR_JTAG_FREQUENCY = LAUNCH_ID + ".jtag_frequency"; //$NON-NLS-1$
     String ATTR_FTDI_DEVICE = LAUNCH_ID + ".ftdi_device"; //$NON-NLS-1$
     String ATTR_FTDI_CORE = LAUNCH_ID + ".ftdi_core"; //$NON-NLS-1$
+
+    static final int UNREAL_DEBUGGER_PLUGIN_VERSION_NUMBER = -1;
+
+    // These version number should be incremented when incompatible changes appear in the debugger plug-in.
+    static final int DEBUGGER_PLUGIN_VERSION_NUMBER = 1;
 
     // Default option values
     static final String DEFAULT_OPENOCD_PORT = "49105";

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/DebuggerPluginVersionsChecker.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/DebuggerPluginVersionsChecker.java
@@ -1,0 +1,61 @@
+package com.arc.embeddedcdt.common;
+
+import java.util.HashSet;
+
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+
+import com.arc.embeddedcdt.LaunchConfigurationConstants;
+import com.arc.embeddedcdt.dsf.utils.Configuration;
+
+public class DebuggerPluginVersionsChecker {
+
+    private HashSet<String> seenLaunchConfigurationNames = new HashSet<>();
+
+    private static DebuggerPluginVersionsChecker INSTANCE = null;
+
+    private ILaunchConfiguration launchConfiguration;
+
+    private DebuggerPluginVersionsChecker() {
+    }
+
+    public static DebuggerPluginVersionsChecker getDebuggerPluginVersionsChecker() {
+        if (INSTANCE == null) {
+            INSTANCE = new DebuggerPluginVersionsChecker();
+        }
+        return INSTANCE;
+    }
+
+    public void checkPluginVersion(ILaunchConfiguration launchConfiguration) {
+        String launchConfigurationName = Configuration.getProgramName(launchConfiguration);
+        if (!seenLaunchConfigurationNames.contains(launchConfigurationName)) {
+            seenLaunchConfigurationNames.add(launchConfigurationName);
+            final int currentLaunchConfigurationDebuggerPluginVersion = Configuration
+                    .getDebuggerPluginVersion(launchConfiguration);
+            if (currentLaunchConfigurationDebuggerPluginVersion != LaunchConfigurationConstants.UNREAL_DEBUGGER_PLUGIN_VERSION_NUMBER
+                    && currentLaunchConfigurationDebuggerPluginVersion != LaunchConfigurationConstants.DEBUGGER_PLUGIN_VERSION_NUMBER) {
+                // Otherwise, a debugger plug-in version was not written to configuration' .launch
+                // file.
+                showWarningWindow(String.format(
+                        "Your debugger plug-in version is %d, but the launch configuration was created with the"
+                                + " plug-in version %d.\n",
+                        LaunchConfigurationConstants.DEBUGGER_PLUGIN_VERSION_NUMBER,
+                        currentLaunchConfigurationDebuggerPluginVersion));
+            }
+        }
+    }
+
+    private void showWarningWindow(final String warningMsg) {
+        Display.getDefault().asyncExec(new Runnable() {
+
+            @Override
+            public void run() {
+                MessageDialog.openWarning(Display.getCurrent().getActiveShell(), "Warning",
+                        "Compatibility issues are possible.\n" + warningMsg);
+            }
+
+        });
+    }
+
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/ArcLaunchDelegate.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/ArcLaunchDelegate.java
@@ -25,6 +25,7 @@ import org.eclipse.debug.core.model.ISourceLocator;
 
 import com.arc.embeddedcdt.dsf.utils.DebugUtils;
 import com.arc.embeddedcdt.launch.LaunchTerminator;
+import com.arc.embeddedcdt.common.DebuggerPluginVersionsChecker;
 
 /**
  * Launch delegate for DSF/GDB debugger.
@@ -63,6 +64,7 @@ public class ArcLaunchDelegate extends GdbLaunchDelegate {
     public void launch(ILaunchConfiguration config, String mode, ILaunch launch,
             IProgressMonitor monitor) throws CoreException {
 
+        DebuggerPluginVersionsChecker.getDebuggerPluginVersionsChecker().checkPluginVersion(config);
         if (monitor == null) {
             monitor = new NullProgressMonitor();
         }

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/Configuration.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/Configuration.java
@@ -48,8 +48,22 @@ public class Configuration {
         }
     }
 
+    private static int getAttribute(ILaunchConfiguration lc, String attribute, int defaultValue) {
+        try {
+            return lc.getAttribute(attribute, defaultValue);
+        } catch (CoreException e) {
+            e.printStackTrace();
+            return defaultValue;
+        }
+    }
+
     public static String getProgramName(ILaunchConfiguration lc) {
         return getAttribute(lc, ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, "");
+    }
+
+    public static int getDebuggerPluginVersion(ILaunchConfiguration lc){
+        return getAttribute(lc, LaunchConfigurationConstants.ATTR_DEBUGGER_PLUGIN_VERSION,
+                LaunchConfigurationConstants.UNREAL_DEBUGGER_PLUGIN_VERSION_NUMBER);
     }
 
     public static String getGdbPath(ILaunchConfiguration lc) {

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGDBDebuggerPage.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGDBDebuggerPage.java
@@ -55,6 +55,7 @@ import org.eclipse.ui.internal.Workbench;
 
 import com.arc.embeddedcdt.LaunchConfigurationConstants;
 import com.arc.embeddedcdt.common.ArcGdbServer;
+import com.arc.embeddedcdt.common.DebuggerPluginVersionsChecker;
 import com.arc.embeddedcdt.common.FtdiCore;
 import com.arc.embeddedcdt.common.FtdiDevice;
 
@@ -239,6 +240,8 @@ public class RemoteGDBDebuggerPage extends GdbDebuggerPage {
         super.setDefaults(configuration);
         configuration.setAttribute(IRemoteConnectionConfigurationConstants.ATTR_GDBSERVER_COMMAND,
                 IRemoteConnectionConfigurationConstants.ATTR_GDBSERVER_COMMAND_DEFAULT);
+        configuration.setAttribute(LaunchConfigurationConstants.ATTR_DEBUGGER_PLUGIN_VERSION,
+                LaunchConfigurationConstants.DEBUGGER_PLUGIN_VERSION_NUMBER);
         configuration.setAttribute(IRemoteConnectionConfigurationConstants.ATTR_GDBSERVER_PORT,
                 IRemoteConnectionConfigurationConstants.ATTR_GDBSERVER_PORT_DEFAULT);
         configuration.setAttribute(LaunchConfigurationConstants.ATTR_DEBUGGER_EXTERNAL_TOOLS,
@@ -320,6 +323,7 @@ public class RemoteGDBDebuggerPage extends GdbDebuggerPage {
 
     @Override
     public void initializeFrom(ILaunchConfiguration configuration) {
+        DebuggerPluginVersionsChecker.getDebuggerPluginVersionsChecker().checkPluginVersion(configuration);
         createTabitemCOMBool = false;
         createTabitemCOMAshlingBool = false;
         createTabitemnSIMBool = false;
@@ -484,6 +488,8 @@ public class RemoteGDBDebuggerPage extends GdbDebuggerPage {
             configuration.setAttribute(LaunchConfigurationConstants.ATTR_JTAG_FREQUENCY,
                     getAttributeValueFromString(jtag_frequency));
 
+        configuration.setAttribute(LaunchConfigurationConstants.ATTR_DEBUGGER_PLUGIN_VERSION,
+                LaunchConfigurationConstants.DEBUGGER_PLUGIN_VERSION_NUMBER);
         configuration.setAttribute(LaunchConfigurationConstants.ATTR_FTDI_DEVICE,
                 getAttributeValueFromString(ftdiDevice.name()));
         configuration.setAttribute(LaunchConfigurationConstants.ATTR_FTDI_CORE,

--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/ARCGCCSpecsRunSIProvider.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/ARCGCCSpecsRunSIProvider.java
@@ -23,23 +23,25 @@ public class ARCGCCSpecsRunSIProvider extends GCCSpecsRunSIProvider {
 
     @Override
     protected String[] setEnvironment(ICommandLauncher launcher, Properties initialEnv) {
+        CompilerPluginVersionsChecker.getCompilerPluginVersionsChecker()
+                .checkPluginVersions(collector);
+
         // Ensure that we have properties.
         Properties props = initialEnv != null ? initialEnv : launcher.getEnvironment();
-        
+
         // Get an absolute path to ../bin.
         String eclipsehome = Platform.getInstallLocation().getURL().getPath();
         File predefined_path_dir = new File(eclipsehome).getParentFile();
-        String predefined_path = predefined_path_dir + File.separator + "bin"+File.separator;
-        
+        String predefined_path = predefined_path_dir + File.separator + "bin" + File.separator;
         // Append ../bin to PATH.
-        if(props!=null){
-        String path = props.getProperty("PATH");
-        if (path!=null&& !path.endsWith(predefined_path)) {
-            path = path + File.pathSeparatorChar + predefined_path;
-            props.setProperty("PATH", path);
+        if (props != null) {
+            String path = props.getProperty("PATH");
+            if (path != null && !path.endsWith(predefined_path)) {
+                path = path + File.pathSeparatorChar + predefined_path;
+                props.setProperty("PATH", path);
+            }
         }
-        }
-        
+
         // Use super-class method to do the rest.
         return super.setEnvironment(launcher, initialEnv);
     }

--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/CompilerPluginVersionsChecker.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/CompilerPluginVersionsChecker.java
@@ -1,0 +1,103 @@
+package org.eclipse.cdt.cross.arc.gnu.common;
+
+import java.util.HashSet;
+
+import org.eclipse.cdt.make.core.scannerconfig.IScannerInfoCollector;
+import org.eclipse.cdt.make.core.scannerconfig.InfoContext;
+import org.eclipse.cdt.make.internal.core.scannerconfig2.PerProjectSICollector;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.osgi.service.prefs.BackingStoreException;
+
+public class CompilerPluginVersionsChecker {
+
+    private final String FILENAME_WITH_PROJECT_SCOPED_PREFERENCES = "com.arc.cdt";
+    private final String UCLIBC_PLUGIN_VERSION = "arc.uclibc_plugin.version";
+    private final String ELF_PLUGIN_VERSION = "arc.elf32_plugin.version";
+
+    // These version numbers should be incremented when incompatible changes appear in these
+    // plug-ins.
+    private final int UCLIBC_PLUGIN_VERSION_NUMBER = 1;
+    private final int ELF_PLUGIN_VERSION_NUMBER = 1;
+
+    private final int UNREAL_VERSION_NUMBER = -1;
+
+    private HashSet<IProject> seenProjects = new HashSet<>();
+
+    private static CompilerPluginVersionsChecker INSTANCE = null;
+
+    private CompilerPluginVersionsChecker() {
+    }
+
+    public static CompilerPluginVersionsChecker getCompilerPluginVersionsChecker() {
+        if (INSTANCE == null) {
+            INSTANCE = new CompilerPluginVersionsChecker();
+        }
+        return INSTANCE;
+    }
+
+    void checkPluginVersions(IScannerInfoCollector collector) {
+        // Write plug-in versions to .settings/com.arc.cdt file if they are not
+        // present, check them otherwise and show warning if there is a
+        // mismatch.
+        InfoContext oC;
+        if ((collector instanceof PerProjectSICollector)) {
+            oC = ((PerProjectSICollector) collector).getContext();
+            IProject oProject = oC.getProject();
+            if (seenProjects.contains(oProject)) {
+                return;
+            }
+            ProjectScope projectScope = new ProjectScope(oProject);
+            IEclipsePreferences pref = projectScope
+                    .getNode(FILENAME_WITH_PROJECT_SCOPED_PREFERENCES);
+            int projectElfPluginVersionNumber = pref.getInt(ELF_PLUGIN_VERSION,
+                    UNREAL_VERSION_NUMBER);
+            int projectUclibcPluginVersionNumber = pref.getInt(UCLIBC_PLUGIN_VERSION,
+                    UNREAL_VERSION_NUMBER);
+            String warningMsg = "";
+            String warningMsgPattern = "Your %s plug-in version is %d, but the project %s was created with the"
+                    + " plug-in version %d.\n";
+            if (projectElfPluginVersionNumber != UNREAL_VERSION_NUMBER) {
+                if (projectElfPluginVersionNumber != ELF_PLUGIN_VERSION_NUMBER) {
+                    warningMsg += String.format(warningMsgPattern, "elf", ELF_PLUGIN_VERSION_NUMBER,
+                            oProject.getName(), projectElfPluginVersionNumber);
+                }
+                if (projectUclibcPluginVersionNumber != UCLIBC_PLUGIN_VERSION_NUMBER) {
+                    warningMsg += String.format(warningMsgPattern, "uclibc",
+                            UCLIBC_PLUGIN_VERSION_NUMBER, oProject.getName(),
+                            projectUclibcPluginVersionNumber);
+                }
+            }
+            if (!warningMsg.equals("")) {
+                showWarningWindow(warningMsg);
+            } else {
+                pref.putInt(ELF_PLUGIN_VERSION, ELF_PLUGIN_VERSION_NUMBER);
+                pref.putInt(UCLIBC_PLUGIN_VERSION, UCLIBC_PLUGIN_VERSION_NUMBER);
+            }
+            try {
+                pref.flush();
+                seenProjects.add(oProject);
+            } catch (BackingStoreException e) {
+                // If attempting to write to the existing project (when importing project) this
+                // exception is also thrown.
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void showWarningWindow(final String warningMsg) {
+        Display.getDefault().asyncExec(new Runnable() {
+
+            @Override
+            public void run() {
+                MessageDialog.openWarning(Display.getCurrent().getActiveShell(), "Warning",
+                        "Compatibility issues are possible.\n" + warningMsg);
+            }
+
+        });
+    }
+
+}


### PR DESCRIPTION
Write compiler plug-in version to $PROJECT/.settings/com.arc.cdt.prefs when
creating a new project. Show warning message when importing, building, debugging
(once per project during a one IDE launch) a project created with an
incompatible compiler plug-in version.

Write debugger plug-in version to
$WORKSPACE/.metadata/.plugins/org.eclipse.debug.core/.launches/$CONFIGURATION_NAME
when creating a new debug configuration. Show warning message when launching,
loading to GUI (once per project during a one IDE launch) a debug
configuration created with an incompatible debugger plug-in version.