### PR TITLE
Add debugger plug-in's launch file format checking

### DIFF
--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/LaunchConfigurationConstants.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/LaunchConfigurationConstants.java
@@ -25,6 +25,9 @@ public interface LaunchConfigurationConstants {
             + ".debugger_build_before_launch";
     static final boolean ATTR_DEBUGGER_BUILD_BEFORE_LAUNCH_DEFAULT = true;
 
+    static final String ATTR_FILE_FORMAT_VERSION =
+        LAUNCH_ID + ".debugger_launch_file_format_version";
+    static final String ATTR_TIMESTAMP = LAUNCH_ID + ".timestamp";
     String ATTR_DEBUGGER_COMMANDS_INIT = LAUNCH_ID + ".debugger_init_commands"; //$NON-NLS-1$
     String ATTR_DEBUGGER_COMMANDS_RUN = LAUNCH_ID + ".debugger_run_commands"; //$NON-NLS-1$
     String ATTR_DEBUGGER_COMMANDS_LAUNCH = LAUNCH_ID + ".debugger_lauch_commands"; //$NON-NLS-1$
@@ -57,6 +60,12 @@ public interface LaunchConfigurationConstants {
     String ATTR_JTAG_FREQUENCY = LAUNCH_ID + ".jtag_frequency"; //$NON-NLS-1$
     String ATTR_FTDI_DEVICE = LAUNCH_ID + ".ftdi_device"; //$NON-NLS-1$
     String ATTR_FTDI_CORE = LAUNCH_ID + ".ftdi_core"; //$NON-NLS-1$
+
+    static final int UNREAL_FILE_FORMAT_VERSION = -1;
+
+    /* This file format number should be incremented when incompatible changes appear in the
+       debugger plug-in. */
+    static final int CURRENT_FILE_FORMAT_VERSION = 1;
 
     // Default option values
     static final String DEFAULT_OPENOCD_PORT = "49105";

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/LaunchFileFormatVersionChecker.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/LaunchFileFormatVersionChecker.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * This program and the accompanying materials are made available under the terms of the Common
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * Copyright (c) 2016 Synopsys, Inc.
+ *******************************************************************************/
+
+package com.arc.embeddedcdt.common;
+
+import java.util.HashSet;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.ui.statushandlers.StatusManager;
+
+import com.arc.embeddedcdt.LaunchConfigurationConstants;
+import com.arc.embeddedcdt.dsf.utils.Configuration;
+
+/**
+ * This class is intended for checking the debugger's file format version and notifying user if his
+ * debug configuration has incompatible changes in comparison with this debugger plug-in's launch
+ * configurations. It makes user aware of possible reason of his problems if they appear.
+ *
+ * It retrieves a launch configuration's file format version from the
+ * $WORKSPACE/.metadata/.plugins/org.eclipse.debug.core/.launches/$CONFIGURATION_NAME, warns user
+ * when launching, loading to GUI (once per project during a one IDE launch) a debug configuration
+ * created with an incompatible debugger's file format version.
+ */
+public class LaunchFileFormatVersionChecker {
+
+  // It is used to avoid duplicating warnings for the same project during a one IDE launch.
+  private final HashSet<String> seenTimestamps = new HashSet<>();
+
+  private static LaunchFileFormatVersionChecker INSTANCE = null;
+
+  private LaunchFileFormatVersionChecker() {}
+
+  public synchronized static LaunchFileFormatVersionChecker getInstance() {
+    if (INSTANCE == null){
+      INSTANCE = new LaunchFileFormatVersionChecker();
+    }
+    return INSTANCE;
+  }
+
+  public void check(final ILaunchConfiguration launchCfg) {
+    final String timestamp = Configuration.getTimeStamp(launchCfg);
+    if (!seenTimestamps.contains(timestamp)) {
+      seenTimestamps.add(timestamp);
+      final int cfgFileVersion = Configuration.getFileFormatVersion(launchCfg);
+      if (cfgFileVersion != LaunchConfigurationConstants.CURRENT_FILE_FORMAT_VERSION) {
+        warnUser(launchCfg, LaunchConfigurationConstants.CURRENT_FILE_FORMAT_VERSION,
+            cfgFileVersion);
+      }
+    }
+  }
+
+  private void warnUser(final ILaunchConfiguration launchCfg, final int currentFileVersion,
+      final int cfgFileVersion) {
+    final String warningMsg =
+        cfgFileVersion == LaunchConfigurationConstants.UNREAL_FILE_FORMAT_VERSION
+            ? String.format("Compatibility issues are possible.\n"
+                + "Your launch configuration's file format version is %d, but this launch "
+                + "configuration was created with a debugger plug-in with an older file format"
+                + " version.", currentFileVersion)
+            : String.format("Compatibility issues are possible.\n"
+                + "Your launch configuration's file format version is %d, but this launch "
+                + "configuration was created with a debugger plug-in with the file format "
+                + "version %d.\n", currentFileVersion, cfgFileVersion);
+
+    final boolean isHeadless = System.getProperty("eclipse.application")
+        .equals("org.eclipse.cdt.managedbuilder.core.headlessbuild");
+    if (isHeadless) {
+      System.err.println(warningMsg);
+    } else {
+      createMarker(launchCfg, warningMsg);
+    }
+  }
+
+  /**
+  * This method makes the warning appear in the Problems view.
+  * If workspace does not exist, a <tt>CoreException</tt> occurs and is reported to the Eclipse's
+  * Error view and error log.
+  */
+  private void createMarker(final ILaunchConfiguration launchCfg, final String warningMsg) {
+    try {
+      final IMarker marker = ResourcesPlugin.getWorkspace().getRoot().createMarker(IMarker.PROBLEM);
+      marker.setAttribute(IMarker.MESSAGE, warningMsg);
+      marker.setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+      marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+      marker.setAttribute(IMarker.LOCATION, launchCfg.getName());
+      marker.setAttribute(IMarker.TRANSIENT, true);
+    } catch (CoreException e) {
+      StatusManager.getManager().handle(e, "com.arc.embeddedcdt");
+    }
+  }
+
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/ArcLaunchDelegate.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/ArcLaunchDelegate.java
@@ -25,6 +25,7 @@ import org.eclipse.debug.core.model.ISourceLocator;
 
 import com.arc.embeddedcdt.dsf.utils.DebugUtils;
 import com.arc.embeddedcdt.launch.LaunchTerminator;
+import com.arc.embeddedcdt.common.LaunchFileFormatVersionChecker;
 
 /**
  * Launch delegate for DSF/GDB debugger.
@@ -63,6 +64,7 @@ public class ArcLaunchDelegate extends GdbLaunchDelegate {
     public void launch(ILaunchConfiguration config, String mode, ILaunch launch,
             IProgressMonitor monitor) throws CoreException {
 
+        LaunchFileFormatVersionChecker.getInstance().check(config);
         if (monitor == null) {
             monitor = new NullProgressMonitor();
         }

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/Configuration.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/Configuration.java
@@ -48,8 +48,26 @@ public class Configuration {
         }
     }
 
+    private static int getAttribute(ILaunchConfiguration lc, String attribute, int defaultValue) {
+        try {
+            return lc.getAttribute(attribute, defaultValue);
+        } catch (CoreException e) {
+            e.printStackTrace();
+            return defaultValue;
+        }
+    }
+
     public static String getProgramName(ILaunchConfiguration lc) {
         return getAttribute(lc, ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, "");
+    }
+
+    public static String getTimeStamp(ILaunchConfiguration lc){
+        return getAttribute(lc, LaunchConfigurationConstants.ATTR_TIMESTAMP, "");
+    }
+
+    public static int getFileFormatVersion(ILaunchConfiguration lc){
+        return getAttribute(lc, LaunchConfigurationConstants.ATTR_FILE_FORMAT_VERSION,
+                LaunchConfigurationConstants.UNREAL_FILE_FORMAT_VERSION);
     }
 
     public static String getGdbPath(ILaunchConfiguration lc) {

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGDBDebuggerPage.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGDBDebuggerPage.java
@@ -55,6 +55,7 @@ import org.eclipse.ui.internal.Workbench;
 
 import com.arc.embeddedcdt.LaunchConfigurationConstants;
 import com.arc.embeddedcdt.common.ArcGdbServer;
+import com.arc.embeddedcdt.common.LaunchFileFormatVersionChecker;
 import com.arc.embeddedcdt.common.FtdiCore;
 import com.arc.embeddedcdt.common.FtdiDevice;
 
@@ -320,6 +321,7 @@ public class RemoteGDBDebuggerPage extends GdbDebuggerPage {
 
     @Override
     public void initializeFrom(ILaunchConfiguration configuration) {
+        LaunchFileFormatVersionChecker.getInstance().check(configuration);
         createTabitemCOMBool = false;
         createTabitemCOMAshlingBool = false;
         createTabitemnSIMBool = false;
@@ -484,6 +486,11 @@ public class RemoteGDBDebuggerPage extends GdbDebuggerPage {
             configuration.setAttribute(LaunchConfigurationConstants.ATTR_JTAG_FREQUENCY,
                     getAttributeValueFromString(jtag_frequency));
 
+        configuration.setAttribute(LaunchConfigurationConstants.ATTR_FILE_FORMAT_VERSION,
+                LaunchConfigurationConstants.CURRENT_FILE_FORMAT_VERSION);
+        // Because there is no setAttribute(String, long) method.
+        configuration.setAttribute(LaunchConfigurationConstants.ATTR_TIMESTAMP,
+                String.format("%d", System.currentTimeMillis()));
         configuration.setAttribute(LaunchConfigurationConstants.ATTR_FTDI_DEVICE,
                 getAttributeValueFromString(ftdiDevice.name()));
         configuration.setAttribute(LaunchConfigurationConstants.ATTR_FTDI_CORE,


### PR DESCRIPTION

Write debugger plug-in version to
$WORKSPACE/.metadata/.plugins/org.eclipse.debug.core/.launches/$CONFIGURATION_NAME
when creating a new debug configuration. Show warning message when
launching, loading to GUI (once per project during a one IDE launch) a
debug configuration created with an incompatible debugger plug-in
version.