### PR TITLE
Add compiler plug-in's state checking

### DIFF
--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/ARCPlugin.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/ARCPlugin.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.cdt.cross.arc.gnu;
 
+import org.eclipse.cdt.cross.arc.gnu.common.StateListener;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Plugin;
@@ -31,6 +33,7 @@ import org.osgi.framework.BundleContext;
    {
      super.start(oContext);
      m_oPlugin = this;
+     ResourcesPlugin.getWorkspace().addResourceChangeListener(StateListener.getInstance());
    }
  
    public void stop(BundleContext oContext) throws Exception {

--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/PreferencesWrapper.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/PreferencesWrapper.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * This program and the accompanying materials are made available under the terms of the Common
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * Copyright (c) 2016 Synopsys, Inc.
+ *******************************************************************************/
+
+package org.eclipse.cdt.cross.arc.gnu.common;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.ui.statushandlers.StatusManager;
+import org.osgi.service.prefs.BackingStoreException;
+
+/**
+ * This class provides an access for both reading and writing to the preferences file.
+ */
+public class PreferencesWrapper {
+
+  public static String get(final String nodeNamePrefix, final IProject project, final String name,
+      final String preference){
+    final ProjectScope projectScope = new ProjectScope(project);
+    final IEclipsePreferences prefs = projectScope.getNode(nodeNamePrefix);
+    return prefs.get(name, "");
+  }
+
+  /**
+   * The <tt>CoreException</tt> occurs if could not flush info to the preferences file, it is
+   * reported to the Eclipse's Error view and error log.
+   */
+  public static void set(final String nodeNamePrefix, final IProject project,
+      final String name, final String preference){
+    final ProjectScope projectScope = new ProjectScope(project);
+    final IEclipsePreferences prefs =
+        projectScope.getNode(nodeNamePrefix);
+    prefs.put(name, preference);
+    final WorkspaceJob job = new WorkspaceJob("Write " + nodeNamePrefix + " for the " +
+    project.getName()) {
+
+      @Override
+      public IStatus runInWorkspace(IProgressMonitor monitor) {
+        try {
+          prefs.flush();
+        } catch (BackingStoreException e) {
+          CoreException coreException =
+              new CoreException(new Status(Status.ERROR, "com.arc.embedded.cdt", e.getMessage()));
+          StatusManager.getManager().handle(coreException, "com.arc.embedded.cdt");
+        }
+        return Status.OK_STATUS;
+      }
+    };
+
+    job.setRule(project);
+    job.schedule();
+  }
+
+}

--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/StateChecker.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/StateChecker.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * This program and the accompanying materials are made available under the terms of the Common
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * Copyright (c) 2016 Synopsys, Inc.
+ *******************************************************************************/
+
+package org.eclipse.cdt.cross.arc.gnu.common;
+
+import org.eclipse.cdt.internal.core.WeakHashSet;
+import org.eclipse.cdt.make.core.scannerconfig.IScannerInfoCollector;
+import org.eclipse.cdt.make.core.scannerconfig.InfoContext;
+import org.eclipse.cdt.make.internal.core.scannerconfig2.PerProjectSICollector;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.ui.statushandlers.StatusManager;
+
+/**
+ * Class is intended for checking the compiler plug-in state number (it may be different for
+ * the same plug-in version) and notifying user if his compiler plug-in has incompatible changes in
+ * comparison with a compiler plug-in a project was created with. It makes user aware of possible
+ * reason of his problems if they appear.
+ *
+ * When creating a new project it writes a compiler plug-in state number to the
+ * $PROJECT/.settings/com.arc.cdt.prefs, warns user when importing, building, debugging (once per
+ * project during a one IDE launch) a project created with an incompatible compiler plug-in state
+ * number.
+ */
+public class StateChecker {
+
+  public static final String PREFS_FILE_NAME_PREFIX = "com.arc.cdt";
+  public static final String STATE_KEY = "com.arc.cdt_plugin.state";
+
+  /* Version number should be incremented when incompatible changes appear in the compiler
+     plug-ins. */
+  public static final String CURRENT_STATE = "1";
+
+  public static final String UNREAL_STATE = "";
+
+  /* Set is used to identify the projects which are already handled. */
+  @SuppressWarnings("restriction")
+  private final WeakHashSet<IProject> seenProjects = new WeakHashSet<>();
+
+  private static StateChecker INSTANCE = null;
+
+  private StateChecker() {
+  }
+
+  public synchronized static StateChecker getInstance() {
+    if (INSTANCE == null){
+      INSTANCE = new StateChecker();
+    }
+    return INSTANCE;
+  }
+
+  /**
+  * Show warning if versions are different (com.arc.cdt.prefs exists) or if there is no
+  * com.arc.cdt.prefs file, but if the project is new, write to preferences file.
+  */
+  @SuppressWarnings("restriction")
+  void checkPluginVersions(final IProject project, boolean isNew) {
+      if (seenProjects.contains(project)) {
+        return;
+      }
+      String projectState = PreferencesWrapper.get(PREFS_FILE_NAME_PREFIX, project, STATE_KEY, UNREAL_STATE);
+      final IPath workspaceLocation = project.getWorkspace().getRoot().getLocation();
+      final IPath projectLocation = project.getLocation().removeLastSegments(1);
+      boolean isImported = !projectLocation.equals(workspaceLocation);
+      if (!projectState.equals(CURRENT_STATE)
+          && (!projectState.equals(UNREAL_STATE) || isImported)) {
+        warnUser(project, CURRENT_STATE, projectState);
+      } else if (projectState.equals(UNREAL_STATE)) {
+           if (isNew){
+             PreferencesWrapper.set(PREFS_FILE_NAME_PREFIX, project, STATE_KEY, CURRENT_STATE);
+           }
+           else{
+             warnUser(project, CURRENT_STATE, UNREAL_STATE);
+           }
+      }
+      seenProjects.add(project);
+    }
+
+  private void warnUser(final IProject project,final String currentState, String projectState) {
+    final String warningMsg = projectState.equals(UNREAL_STATE)
+        ? String.format("Compatibility issues are possible.\n"
+            + "Your compiler plug-in' state is %s, but this project was created with an "
+            + "older compiler plug-in' state.", currentState)
+        : String.format("Compatibility issues are possible.\n"
+            + "Your compiler plug-in' state is %s, but this project was created with a "
+            + "compiler state %s.", currentState, projectState);
+
+    final boolean isHeadless = System.getProperty("eclipse.application")
+        .equals("org.eclipse.cdt.managedbuilder.core.headlessbuild");
+    if (isHeadless) {
+      System.err.println(warningMsg);
+    } else {
+      createMarker(project, warningMsg);
+    }
+  }
+
+  /**
+   * This method makes the warning appear in the Problems view.
+   * If a project does not exist or is closed, a <tt>CoreException</tt> occurs and is reported
+   * to the Eclipse's Error view and error log.
+   */
+  private void createMarker(final IProject project, final String warningMsg) {
+    final WorkspaceJob job = new WorkspaceJob(
+        "Create marker for an incompatible compiler plug-in version" + project.getName()) {
+
+      @Override
+      public IStatus runInWorkspace(IProgressMonitor monitor) {
+        try {
+          IMarker marker = project.createMarker(IMarker.PROBLEM);
+          marker.setAttribute(IMarker.MESSAGE, warningMsg);
+          marker.setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+          marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+          marker.setAttribute(IMarker.LOCATION, project.getName());
+          marker.setAttribute(IMarker.TRANSIENT, true);
+        } catch (CoreException exception) {
+          StatusManager.getManager().handle(exception, "com.arc.embeddedcdt");
+        }
+        return Status.OK_STATUS;
+      }
+    };
+    job.setRule(project);
+    job.schedule();
+  }
+}

--- a/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/StateListener.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/org/eclipse/cdt/cross/arc/gnu/common/StateListener.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * This program and the accompanying materials are made available under the terms of the Common
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * Copyright (c) 2016 Synopsys, Inc.
+ *******************************************************************************/
+
+package org.eclipse.cdt.cross.arc.gnu.common;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+
+/**
+ * This class is intended for tracking the projects' changes and notifying StateChecker.
+ */
+public class StateListener implements IResourceChangeListener {
+
+  private static StateListener INSTANCE = null;
+
+  private StateChecker checker = StateChecker.getInstance();
+  public synchronized static StateListener getInstance() {
+    if (INSTANCE == null) {
+      INSTANCE = new StateListener();
+    }
+    return INSTANCE;
+  }
+
+  private StateListener() {
+  }
+
+  @Override
+  public void resourceChanged(IResourceChangeEvent event) {
+    final IResourceDelta delta = event.getDelta();
+    if (delta.getKind() == IResourceDelta.CHANGED) {
+      IResourceDelta[] addedResources = delta.getAffectedChildren(IResourceDelta.ADDED);
+      IResourceDelta[] changedResources = delta.getAffectedChildren(IResourceDelta.CHANGED);
+      for (IResourceDelta resourceDelta : changedResources) {
+        final IResource resource = resourceDelta.getResource();
+        if (resource instanceof IProject) {
+          final IProject project = (IProject) resource;
+          checker.checkPluginVersions(project, false);
+        }
+      }
+      for (IResourceDelta resourceDelta : addedResources) {
+        final IResource resource = resourceDelta.getResource();
+        if (resource instanceof IProject) {
+          final IProject project = (IProject) resource;
+          checker.checkPluginVersions(project, true);
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Write the compiler plug-in version to $PROJECT/.settings/com.arc.cdt.prefs
when creating a new project. Show warning message when importing,
building, debugging (once per project during a one IDE launch) a project
created with an incompatible compiler plug-in version.