### PR TITLE
Remove settings options with the same id' suffices to the same value when changing one of them

### DIFF
--- a/org.eclipse.cdt.cross.arc.gnu.uclibc/src/com/arc/cdt/toolchain/OptionEnablementManager.java
+++ b/org.eclipse.cdt.cross.arc.gnu.uclibc/src/com/arc/cdt/toolchain/OptionEnablementManager.java
@@ -85,23 +85,6 @@ public class OptionEnablementManager extends AbstractOptionEnablementManager {
             	}
             	setEnabled(ANSI_MODE,ansiPermitted);           	
             }
-            
-            // Get suffix of option and make sure all with same suffix
-            // are set to same value.
-            // For example "arc.asm.options.arc5core" and
-            // "arc.compiler.options.arc5core" must match.
-            // HACK: except for ".level". We don't want optimization level to be mistaken for
-            // debug level!
-            Object v = mgr.getValue(optionId);
-            if (v instanceof String || v instanceof Boolean) {
-                String suffix = getSuffixOf(optionId);
-                //Make copy to avoid occasional ConcurrentModificationException
-                for (String id : new ArrayList<String>(getOptionIds())) {
-                    if (suffix.equals(getSuffixOf(id)) && !id.equals(optionId) && !suffix.equals("level")) {
-                        setOptionValue(id, v);
-                    }
-                }
-            }
         }
 
 

--- a/org.eclipse.cdt.cross.arc.gnu/src/com/arc/cdt/toolchain/OptionEnablementManager.java
+++ b/org.eclipse.cdt.cross.arc.gnu/src/com/arc/cdt/toolchain/OptionEnablementManager.java
@@ -85,23 +85,6 @@ public class OptionEnablementManager extends AbstractOptionEnablementManager {
             	}
             	setEnabled(ANSI_MODE,ansiPermitted);           	
             }
-            
-            // Get suffix of option and make sure all with same suffix
-            // are set to same value.
-            // For example "arc.asm.options.arc5core" and
-            // "arc.compiler.options.arc5core" must match.
-            // HACK: except for ".level". We don't want optimization level to be mistaken for
-            // debug level!
-            Object v = mgr.getValue(optionId);
-            if (v instanceof String || v instanceof Boolean) {
-                String suffix = getSuffixOf(optionId);
-                //Make copy to avoid occasional ConcurrentModificationException
-                for (String id : new ArrayList<String>(getOptionIds())) {
-                    if (suffix.equals(getSuffixOf(id)) && !id.equals(optionId) && !suffix.equals("level")) {
-                        setOptionValue(id, v);
-                    }
-                }
-            }
         }
 
 


### PR DESCRIPTION

This causes errors, because options with different meaning can have the
same id' suffices (name in GUI), e.g. "other flags" of compiler
and "other flags" of linker can vary. This commit fixes the
STAR-9001091993 "Changing linker settings breaks the project build".