### PR TITLE
Replace '\' in a value for "C/C++ Application:" field in "Debug confi…

### DIFF
--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGDBDebuggerPage.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGDBDebuggerPage.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 
 import org.eclipse.cdt.dsf.gdb.internal.ui.launching.GdbDebuggerPage;
+import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.dsf.gdb.IGDBLaunchConfigurationConstants;
 import org.eclipse.cdt.internal.launch.remote.Messages;
 import org.eclipse.cdt.launch.remote.IRemoteConnectionConfigurationConstants;
@@ -56,6 +57,7 @@ import org.eclipse.ui.internal.Workbench;
 import com.arc.embeddedcdt.LaunchConfigurationConstants;
 import com.arc.embeddedcdt.common.ArcGdbServer;
 import com.arc.embeddedcdt.common.LaunchFileFormatVersionChecker;
+import com.arc.embeddedcdt.dsf.utils.Configuration;
 import com.arc.embeddedcdt.common.FtdiCore;
 import com.arc.embeddedcdt.common.FtdiDevice;
 
@@ -471,6 +473,9 @@ public class RemoteGDBDebuggerPage extends GdbDebuggerPage {
     @Override
     public void performApply(ILaunchConfigurationWorkingCopy configuration) {
         super.performApply(configuration);
+        final String programName = Configuration.getProgramName(configuration);
+        configuration.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
+            programName.replace('\\', '/'));
         if (!groupnsim.isDisposed()) {
             fWorkingDirectoryBlockNSim.performApply(configuration);
         }


### PR DESCRIPTION
…gurations"

window  with '/'

'\' in path to an executable causes error on Windows when launching debug
configuration, because GDB treats '\' as a beginning of an escape sequence.
Now '\' is always replaced with '/' when launch happens and '/' is shown
in path to an executable in GUI next time you open the debug configuration in GUI.