### PR TITLE
Fix refactoring

### DIFF
--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/ArcGdbServer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/ArcGdbServer.java
@@ -10,23 +10,33 @@
 
 package com.arc.embeddedcdt.common;
 
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Text;
+
+import com.arc.embeddedcdt.LaunchConfigurationConstants;
+
 public enum ArcGdbServer {
-    JTAG_OPENOCD("JTAG via OpenOCD"),
-    JTAG_ASHLING("JTAG via Opella-XD"),
-    NSIM("nSIM"),
-    GENERIC_GDBSERVER("Connect to running GDB server"),
-    CUSTOM_GDBSERVER("Custom GDB server");
-
-    private final String string;
+    JTAG_OPENOCD("JTAG via OpenOCD", LaunchConfigurationConstants.DEFAULT_OPENOCD_PORT),
+    JTAG_ASHLING("JTAG via Opella-XD", LaunchConfigurationConstants.DEFAULT_OPELLAXD_PORT),
+    NSIM("nSIM", LaunchConfigurationConstants.DEFAULT_NSIM_PORT),
+    GENERIC_GDBSERVER("Connect to running GDB server", null),
+    CUSTOM_GDBSERVER("Custom GDB server", LaunchConfigurationConstants.DEFAULT_OPELLAXD_PORT);
+    
+    private final String stringRepresentation;
     public static final ArcGdbServer DEFAULT_GDB_SERVER = JTAG_OPENOCD;
-
-    private ArcGdbServer(final String text) {
-        this.string = text;
+    private Group guiGroup;
+    private final String defaultPortNumber;
+    private String portNumber = "";
+    protected Text gdbServerPortNumberText;
+    
+    private ArcGdbServer(final String text, final String defaultPortNumber) {
+        stringRepresentation = text;
+        this.defaultPortNumber = defaultPortNumber;
     }
 
     @Override
     public String toString() {
-        return string;
+        return stringRepresentation;
     }
 
     public static ArcGdbServer fromString(final String string) {

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/ComAshlingGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/ComAshlingGroupContainer.java
@@ -1,0 +1,18 @@
+package com.arc.embeddedcdt.gui;
+
+import org.eclipse.swt.widgets.Composite;
+
+public class ComAshlingGroupContainer extends DebuggerGroupContainer{
+
+  public ComAshlingGroupContainer(RemoteGdbDebuggerPageGui pageGui) {
+    super(pageGui);
+    // TODO Auto-generated constructor stub
+  }
+
+  @Override
+  public void createTab(Composite comp, RemoteGdbDebuggerPage caller) {
+    // TODO Auto-generated method stub
+    
+  }
+
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/ComCustomGdbGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/ComCustomGdbGroupContainer.java
@@ -1,0 +1,27 @@
+package com.arc.embeddedcdt.gui;
+
+import org.eclipse.swt.widgets.Composite;
+
+public class ComCustomGdbGroupContainer extends DebuggerGroupContainer{
+
+  public ComCustomGdbGroupContainer(RemoteGdbDebuggerPageGui pageGui) {
+    super(pageGui);
+    // TODO Auto-generated constructor stub
+  }
+
+  @Override
+  public void chosenInGui(Composite comp, RemoteGdbDebuggerPage caller) {
+    super.chosenInGui(comp, caller);
+    updateLaunchConfigurationDialog();
+  }
+  
+  private void updateLaunchConfigurationDialog(){
+    
+  }
+
+  @Override
+  public void createTab(Composite comp, RemoteGdbDebuggerPage caller) {
+    // TODO Auto-generated method stub
+    
+  }
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/ComGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/ComGroupContainer.java
@@ -1,0 +1,195 @@
+package com.arc.embeddedcdt.gui;
+
+import java.io.File;
+
+import org.eclipse.debug.internal.ui.SWTFactory;
+import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.jface.preference.StringButtonFieldEditor;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Spinner;
+import org.eclipse.swt.widgets.Text;
+
+import com.arc.embeddedcdt.LaunchConfigurationConstants;
+import com.arc.embeddedcdt.common.ArcGdbServer;
+import com.arc.embeddedcdt.common.FtdiCore;
+import com.arc.embeddedcdt.common.FtdiDevice;
+
+public class ComGroupContainer extends DebuggerGroupContainer {
+
+  public ComGroupContainer(RemoteGdbDebuggerPageGui pageGui) {
+    super(pageGui);
+    defaultPortNumber = LaunchConfigurationConstants.DEFAULT_OPENOCD_PORT;
+  }
+
+  @Override
+  public void createTab(Composite subComp, final RemoteGdbDebuggerPage caller) {
+    createTabItem = true;
+    guiGroup = SWTFactory.createGroup(subComp, pageGui.externalToolsCombo.getItem(0), 3, 5,
+        GridData.FILL_HORIZONTAL);
+    DebuggerGroupManager.guiGroupByGdbServer.put(ArcGdbServer.JTAG_OPENOCD, guiGroup);
+    final Composite compositeCom = SWTFactory.createComposite(guiGroup, 3, 5, GridData.FILL_BOTH);
+
+    // Path to OpenOCD binary
+    pageGui.openOcdBinPathEditor = new FileFieldEditor("openocdBinaryPathEditor", "OpenOCD executable",
+        false, StringButtonFieldEditor.VALIDATE_ON_KEY_STROKE, compositeCom);
+    pageGui.openOcdBinPathEditor.setStringValue(pageGui.openOcdBinaryPath);
+    pageGui.openOcdBinPathEditor.setPropertyChangeListener(new IPropertyChangeListener() {
+      public void propertyChange(PropertyChangeEvent event) {
+        if (event.getProperty() == "field_editor_value") {
+          pageGui.openOcdBinaryPath = (String) event.getNewValue();
+          if (pageGui.ftdiDevice != FtdiDevice.CUSTOM) {
+            pageGui.openOcdConfigurationPath = getOpenOcdConfigurationPath();
+            pageGui.openOcdConfigurationPathEditor.setStringValue(pageGui.openOcdConfigurationPath);
+          }
+          caller.updateLaunchConfigurationDialogPublic();
+        }
+      }
+    });
+    Label label = new Label(compositeCom, SWT.LEFT);
+    label.setText("Development system:");
+    pageGui.ftdiDeviceCombo = new Combo(compositeCom, SWT.None | SWT.READ_ONLY);// 1-2 and 1-3
+
+    GridData gridDataJtag = new GridData(GridData.BEGINNING);
+    gridDataJtag.widthHint = 220;
+    gridDataJtag.horizontalSpan = 2;
+    pageGui.ftdiDeviceCombo.setLayoutData(gridDataJtag);
+
+    for (FtdiDevice i : FtdiDevice.values())
+      pageGui.ftdiDeviceCombo.add(i.toString());
+    pageGui.ftdiDeviceCombo.setText(pageGui.ftdiDevice.toString());
+
+    pageGui.ftdiDeviceCombo.addModifyListener(new ModifyListener() {
+      public void modifyText(ModifyEvent event) {
+        Combo combo = (Combo) event.widget;
+        pageGui.ftdiDevice = FtdiDevice.fromString(combo.getText());
+
+        if (pageGui.ftdiDevice == FtdiDevice.CUSTOM)
+          pageGui.openOcdConfigurationPathEditor.setEnabled(true, compositeCom);
+        else
+          pageGui.openOcdConfigurationPathEditor.setEnabled(false, compositeCom);
+
+        if (pageGui.ftdiDevice.getCores().size() <= 1)
+          pageGui.ftdiCoreCombo.setEnabled(false);
+        else
+          pageGui.ftdiCoreCombo.setEnabled(true);
+
+        updateFtdiCoreCombo();
+        caller.updateLaunchConfigurationDialogPublic();
+      }
+    });
+
+    Label coreLabel = new Label(compositeCom, SWT.LEFT);
+    coreLabel.setText("Target Core");
+    pageGui.ftdiCoreCombo = new Combo(compositeCom, SWT.None | SWT.READ_ONLY);// 1-2 and 1-3
+    pageGui.ftdiCoreCombo.setLayoutData(gridDataJtag);
+
+    if (pageGui.ftdiDevice.getCores().size() <= 1)
+      pageGui.ftdiCoreCombo.setEnabled(false);
+    else
+      pageGui.ftdiCoreCombo.setEnabled(true);
+
+    updateFtdiCoreCombo();
+
+    pageGui.ftdiCoreCombo.addModifyListener(new ModifyListener() {
+      public void modifyText(ModifyEvent event) {
+        Combo combo = (Combo) event.widget;
+        if (!combo.getText().isEmpty()) {
+          pageGui.ftdiCore = FtdiCore.fromString(combo.getText());
+          if (pageGui.ftdiDevice != FtdiDevice.CUSTOM) {
+            pageGui.openOcdConfigurationPath = getOpenOcdConfigurationPath();
+            pageGui.openOcdConfigurationPathEditor.setStringValue(pageGui.openOcdConfigurationPath);
+          }
+        }
+        caller.updateLaunchConfigurationDialogPublic();
+      }
+    });
+
+    pageGui.openOcdConfigurationPathEditor =
+        new FileFieldEditor("openocdConfigurationPathEditor", "OpenOCD configuration file", false,
+            StringButtonFieldEditor.VALIDATE_ON_KEY_STROKE, compositeCom);
+    pageGui.openOcdConfigurationPathEditor.setEnabled(false, compositeCom);
+    pageGui.openOcdConfigurationPathEditor.setStringValue(pageGui.openOcdConfigurationPath);
+    pageGui.openOcdConfigurationPathEditor.setPropertyChangeListener(new IPropertyChangeListener() {
+      public void propertyChange(PropertyChangeEvent event) {
+        if (event.getProperty() == "field_editor_value") {
+          pageGui.openOcdConfigurationPath = event.getNewValue().toString();
+          caller.updateLaunchConfigurationDialogPublic();
+        }
+      }
+    });
+
+    if (pageGui.openOcdConfigurationPathEditor != null) {
+      if (!pageGui.ftdiDeviceCombo.getText().equalsIgnoreCase(FtdiDevice.CUSTOM.toString())) {
+        pageGui.openOcdConfigurationPathEditor.setEnabled(false, compositeCom);
+      } else {
+        pageGui.openOcdConfigurationPathEditor.setEnabled(true, compositeCom);
+      }
+    }
+  }
+  
+  private String getOpenOcdConfigurationPath() {
+    final File rootDirectory = new File(pageGui.openOcdBinaryPath).getParentFile().getParentFile();
+    final File scriptsDirectory = new File(rootDirectory,
+            "share" + File.separator + "openocd" + File.separator + "scripts");
+    String openOcdConfiguration = scriptsDirectory + File.separator + "board" + File.separator;
+
+    switch (pageGui.ftdiDevice) {
+    case EM_SK_v1x:
+        openOcdConfiguration += "snps_em_sk_v1.cfg";
+        break;
+    case EM_SK_v21:
+        openOcdConfiguration += "snps_em_sk_v2.1.cfg";
+        break;
+    case EM_SK_v22:
+        openOcdConfiguration += "snps_em_sk_v2.2.cfg";
+        break;
+    case AXS101:
+        openOcdConfiguration += "snps_axs101.cfg";
+        break;
+    case AXS102:
+        openOcdConfiguration += "snps_axs102.cfg";
+        break;
+    case AXS103:
+        if (pageGui.ftdiCore == FtdiCore.HS36) {
+            openOcdConfiguration += "snps_axs103_hs36.cfg";
+        } else {
+            openOcdConfiguration += "snps_axs103_hs38.cfg";
+        }
+        break;
+    case CUSTOM:
+        break;
+    default:
+        throw new IllegalArgumentException("Unknown enum value has been used");
+    }
+    return openOcdConfiguration;
+  }
+
+  private void updateFtdiCoreCombo() {
+    pageGui.ftdiCoreCombo.removeAll();
+    java.util.List<FtdiCore> cores = pageGui.ftdiDevice.getCores();
+    String text = cores.get(0).toString();
+    for (FtdiCore core : cores) {
+        pageGui.ftdiCoreCombo.add(core.toString());
+        if (pageGui.ftdiCore == core) {
+            /*
+             * Should select current ftdiCore if it is present in cores list in order to be able
+             * to initialize from configuration. Otherwise ftdiCore field will be rewritten to
+             * the selected core when we initialize FTDI_DeviceCombo
+             */
+            text = core.toString();
+        }
+    }
+    pageGui.ftdiCoreCombo.setText(text);
+  }
+  
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
@@ -1,0 +1,57 @@
+package com.arc.embeddedcdt.gui;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Text;
+
+import com.arc.embeddedcdt.common.ArcGdbServer;
+
+abstract class DebuggerGroupContainer{
+  
+  public Group guiGroup;
+  protected String defaultPortNumber;
+  private String portNumber = "";
+  protected boolean createTabItem = false;
+  
+  RemoteGdbDebuggerPageGui pageGui;
+  
+  public DebuggerGroupContainer(RemoteGdbDebuggerPageGui pageGui){
+    this.pageGui = pageGui;
+  }
+  
+  public Group getGroup(){
+    return guiGroup;
+  }
+  
+  public void chosenInGui(Composite subComp, final RemoteGdbDebuggerPage caller){
+    for (ArcGdbServer server : ArcGdbServer.values()){
+      if (server != pageGui.gdbServer){
+        Group group = DebuggerGroupManager.guiGroupByGdbServer.get(server);
+        if (pageGui.gdbServer != null && group != null){
+          group.dispose();
+        }
+      }
+    }
+    if (portNumber != null) {
+      if (!portNumber.isEmpty()) {
+        pageGui.gdbServerPortNumberText.setText(portNumber);
+      } else {
+        pageGui.gdbServerPortNumberText.setText(defaultPortNumber);
+      }
+    }
+    if (createTabItem == false) {
+      if (!guiGroup.isDisposed()){
+          guiGroup.dispose();
+      }
+
+      createTab(subComp, caller);
+    }
+    else{
+      guiGroup.setText(pageGui.gdbServer.toString());
+      guiGroup.setVisible(true);
+    }
+  }
+  
+  public abstract void createTab(Composite comp, RemoteGdbDebuggerPage caller);
+  
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupManager.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupManager.java
@@ -1,0 +1,41 @@
+package com.arc.embeddedcdt.gui;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+
+import com.arc.embeddedcdt.common.ArcGdbServer;
+
+public class DebuggerGroupManager {
+
+  public static HashMap<ArcGdbServer, Group> guiGroupByGdbServer = new HashMap<>();
+  
+  public static HashSet<DebuggerGroupContainer> groupContainers = new HashSet<>();
+  
+  public DebuggerGroupManager(final List<DebuggerGroupContainer> containers) {
+    /*groupContainers.add(new ComAshlingGroupContainer());
+    groupContainers.add(new ComGroupContainer());
+    groupContainers.add(new ComCustomGdbGroupContainer());
+    groupContainers.add(new GenericGdbServerGroupContainer());
+    groupContainers.add(new NsimGroupContainer());*/
+    groupContainers.addAll(containers);
+  }
+  
+  ComAshlingGroupContainer groupComAshling;
+  ComCustomGdbGroupContainer groupComCustomGdb;
+  ComGroupContainer groupCom;
+  NsimGroupContainer groupNsim;
+  GenericGdbServerGroupContainer groupGenericGdbServer;
+  
+  
+  public void createTabItemsIfNotCreated(Composite subComp, RemoteGdbDebuggerPage caller){
+    for (DebuggerGroupContainer groupContainer : groupContainers){
+      if (groupContainer.createTabItem == false){
+        groupContainer.createTab(subComp, caller);
+      }
+    }
+  }
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/GenericGdbServerGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/GenericGdbServerGroupContainer.java
@@ -1,0 +1,18 @@
+package com.arc.embeddedcdt.gui;
+
+import org.eclipse.swt.widgets.Composite;
+
+public class GenericGdbServerGroupContainer extends DebuggerGroupContainer{
+
+  public GenericGdbServerGroupContainer(RemoteGdbDebuggerPageGui pageGui) {
+    super(pageGui);
+    // TODO Auto-generated constructor stub
+  }
+
+  @Override
+  public void createTab(Composite comp, RemoteGdbDebuggerPage caller) {
+    // TODO Auto-generated method stub
+    
+  }
+
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/NsimGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/NsimGroupContainer.java
@@ -1,0 +1,18 @@
+package com.arc.embeddedcdt.gui;
+
+import org.eclipse.swt.widgets.Composite;
+
+public class NsimGroupContainer extends DebuggerGroupContainer{
+
+  public NsimGroupContainer(RemoteGdbDebuggerPageGui pageGui) {
+    super(pageGui);
+    // TODO Auto-generated constructor stub
+  }
+
+  @Override
+  public void createTab(Composite comp, RemoteGdbDebuggerPage caller) {
+    // TODO Auto-generated method stub
+    
+  }
+
+}

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGdbDebuggerPageGui.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/RemoteGdbDebuggerPageGui.java
@@ -1,0 +1,45 @@
+package com.arc.embeddedcdt.gui;
+
+import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Spinner;
+import org.eclipse.swt.widgets.Text;
+
+import com.arc.embeddedcdt.LaunchConfigurationConstants;
+import com.arc.embeddedcdt.common.ArcGdbServer;
+import com.arc.embeddedcdt.common.FtdiCore;
+import com.arc.embeddedcdt.common.FtdiDevice;
+
+public class RemoteGdbDebuggerPageGui {
+
+  public Combo externalToolsCombo;
+  public ArcGdbServer gdbServer;
+  
+  public Combo ftdiDeviceCombo;
+  public Combo ftdiCoreCombo;
+  public Text targetText;
+  public Text gdbServerPortNumberText;
+  public Text gdbServerIpAddressText;
+  public Button searchExternalToolsPathButton;
+  public Label searchExternalToolsLabel;
+  public Text externalToolsPathText;
+  public FileFieldEditor openOcdBinPathEditor;
+  public FileFieldEditor openOcdConfigurationPathEditor;
+  public String openOcdBinaryPath;
+  public String openOcdConfigurationPath;
+  public FtdiDevice ftdiDevice = LaunchConfigurationConstants.DEFAULT_FTDI_DEVICE;
+  public FtdiCore ftdiCore = LaunchConfigurationConstants.DEFAULT_FTDI_CORE;
+  public Button nsimPropertiesBrowseButton;
+  public Button launchTcf;
+  public Button launchTcfPropertiesButton;
+  public Button launchNsimJitProperties;
+  public Button launchHostLinkProperties;
+  public Button launchMemoryExceptionProperties;
+  public Button launchInvalidInstructionExceptionProperties;
+  public Button launchEnableExceptionProperties;
+  public Button nsimTcfBrowseButton;
+
+  public Spinner jitThreadSpinner;
+}


### PR DESCRIPTION
There are five initial dummies for the gdb servers, some logic is extracted only for open ocd gdb server. DebuggerGroupManager is to dispose tabs for other servers then one is chosen in the combobox. RemoteGdbDebuggerPage is changed just to make it all work, nothing new in it. RemoteGdbDebuggerPageGui is to synchronize values of variables in the RemoteGdbDebuggerPage and dummies, I hope we will not need this class when I finish extraction.
Succeed with avoiding of NPEs, but have some issues when creating debug configuration.