### PR TITLE
Replace Hello World project templates for EM SK 2.1 with 2.3/2.2

### DIFF
--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/FtdiDevice.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/FtdiDevice.java
@@ -17,8 +17,6 @@ import java.util.Arrays;
 public enum FtdiDevice {
     EM_SK_v1x("EM Starter Kit v1.x"),
     EM_SK_v2("EM Starter Kit v2"),
-    EM_SK_v21("EM Starter Kit v2.1"),
-    EM_SK_v22("EM Starter Kit v2.2"),
     AXS101("AXS101", Arrays.asList(FtdiCore.AS221_1, FtdiCore.AS221_2, FtdiCore.EM6,
             FtdiCore.ARC770D)),
     AXS102("AXS102", Arrays.asList(FtdiCore.HS34, FtdiCore.HS36)),

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
@@ -575,11 +575,6 @@ public class DebuggerGroupContainer extends Observable{
         break;
     case EM_SK_v2:
         openOcdConfiguration += "snps_em_sk.cfg";
-    case EM_SK_v21:
-        openOcdConfiguration += "snps_em_sk_v2.1.cfg";
-        break;
-    case EM_SK_v22:
-        openOcdConfiguration += "snps_em_sk_v2.2.cfg";
         break;
     case AXS101:
         openOcdConfiguration += "snps_axs101.cfg";


### PR DESCRIPTION
Tested with the 2.3 board with all of the cores, all projects were debugged successfully.
P.S. Anton, debugging with the 9d core began to behave normally after I have applied changes to the lds files' ICCM and DCCM length.