### PR TITLE
Fix bugs (EM9D memory maps and terminal view)

### DIFF
--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/TerminalService.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/TerminalService.java
@@ -57,6 +57,11 @@ public class TerminalService extends AbstractDsfService {
         properties.put(SerialSettings.STOP_BITS_ATTR, StopBits.S1);
         properties.put(SerialSettings.PARITY_ATTR, Parity.None);
         properties.put(SerialSettings.BYTE_SIZE_ATTR, ByteSize.getDefault());
+        
+        properties.put(ITerminalsConnectorConstants.PROP_TIMEOUT, "5");
+        properties.put(ITerminalsConnectorConstants.PROP_SERIAL_DATA_BITS, "8");
+        properties.put(ITerminalsConnectorConstants.PROP_SERIAL_FLOW_CONTROL, "XON/XOFF");
+        properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID, delegateId);
     }
     private ITerminalService terminal = TerminalServiceFactory.getService();
     private ILauncherDelegate delegate = LauncherDelegateManager.getInstance()

--- a/org.eclipse.cdt.cross.arc.gnu/templates/projecttemplates/EM9_Empty_CPP_Project/lds/arcelf.lds
+++ b/org.eclipse.cdt.cross.arc.gnu/templates/projecttemplates/EM9_Empty_CPP_Project/lds/arcelf.lds
@@ -1,17 +1,16 @@
 MEMORY
 {
     ICCM : ORIGIN = 0x00000000, LENGTH = 256K
-    DRAM : ORIGIN = 0x10000000, LENGTH = 128M
     DCCM : ORIGIN = 0x80000000, LENGTH = 128K
 }
 
 REGION_ALIAS("startup", ICCM)
 REGION_ALIAS("text", ICCM)
-REGION_ALIAS("data", DRAM)
-REGION_ALIAS("sdata", DRAM)
+REGION_ALIAS("data", DCCM)
+REGION_ALIAS("sdata", DCCM)
 
-PROVIDE (__stack_top = (0x17FFFFFF & -4) );
-PROVIDE (__end_heap = (0x17FFFFFF) );
+PROVIDE (__stack_top = (0x8001FFFF & -4) );
+PROVIDE (__end_heap = (0x8001FFFF) );
 
 ENTRY(__start)
 

--- a/org.eclipse.cdt.cross.arc.gnu/templates/projecttemplates/EM9_Empty_C_Project/lds/arcelf.lds
+++ b/org.eclipse.cdt.cross.arc.gnu/templates/projecttemplates/EM9_Empty_C_Project/lds/arcelf.lds
@@ -1,18 +1,16 @@
 MEMORY
 {
     ICCM : ORIGIN = 0x00000000, LENGTH = 256K
-    DRAM : ORIGIN = 0x10000000, LENGTH = 128M
     DCCM : ORIGIN = 0x80000000, LENGTH = 128K
 }
 
 REGION_ALIAS("startup", ICCM)
 REGION_ALIAS("text", ICCM)
-REGION_ALIAS("data", DRAM)
-REGION_ALIAS("sdata", DRAM)
+REGION_ALIAS("data", DCCM)
+REGION_ALIAS("sdata", DCCM)
 
-PROVIDE (__stack_top = (0x17FFFFFF & -4) );
-PROVIDE (__end_heap = (0x17FFFFFF) );
-
+PROVIDE (__stack_top = (0x8001FFFF & -4) );
+PROVIDE (__end_heap = (0x8001FFFF) );
 ENTRY(__start)
 
 SECTIONS


### PR DESCRIPTION
Now EM9D projects work correct and terminal view opens when debug starts
(changes are made in EM9D memory map and in com.arc.embeddedcdt.dsf
TerminalService class)