### PR TITLE
Introduce a separate source for CDT as 10.6 moved to the archive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <eclipse.mirror>http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse</eclipse.mirror>
     <eclipse.version>2022-03</eclipse.version>
     <!-- Path to CDT p2 repository -->
+    <cdt.mirror>https://archive.eclipse.org</cdt.mirror>
     <cdt.version>10.6</cdt.version>
     <tycho-version>1.3.0</tycho-version>
   </properties>
@@ -24,7 +25,7 @@
   <repositories>
     <repository>
       <id>cdt</id>
-      <url>${eclipse.mirror}/tools/cdt/releases/${cdt.version}/</url>
+      <url>${cdt.mirror}/tools/cdt/releases/${cdt.version}/</url>
       <layout>p2</layout>
     </repository>
     <repository>


### PR DESCRIPTION
CDT 10.6 was moved to the archive and so is no longer available from the same location as the Eclipse itself.

At the same time the archive doesn't have all the other components, so we'll have 2 separate location for now.