### PR TITLE
Add Ashling OpellaXD/Vitra-XS probe support for ARC debugging

### DIFF
--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/LaunchConfigurationConstants.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/LaunchConfigurationConstants.java
@@ -54,9 +54,10 @@ public interface LaunchConfigurationConstants {
     String ATTR_DEBUGGER_GDB_ADDRESS = LAUNCH_ID + ".debugger_gdb_address"; //$NON-NLS-1$
     String ATTR_NSIM_PROP_FILE = LAUNCH_ID + ".nsim_prop_file"; //$NON-NLS-1$
     String ATTR_NSIM_TCF_FILE = LAUNCH_ID + ".nsim_tcf_file"; //$NON-NLS-1$
-    String ATTR_ASHLING_XML_PATH = LAUNCH_ID + ".ashling_xml_path"; //$NON-NLS-1$
-    String ATTR_ASHLING_TDESC_PATH = LAUNCH_ID + ".ashling_tdesc_path"; //$NON-NLS-1$
     String ATTR_JTAG_FREQUENCY = LAUNCH_ID + ".jtag_frequency"; //$NON-NLS-1$
+    String ATTR_ASHLING_DEVICE = LAUNCH_ID + ".ashling_device"; //$NON-NLS-1$
+    String ATTR_ASHLING_PROBE_SERIAL_NUMBER = LAUNCH_ID + ".ashling_probe_serial_number"; //$NON-NLS-1$
+    String ATTR_ASHLING_GDBSERVER_ARGS = LAUNCH_ID + ".ashling_gdbserver_args"; //$NON-NLS-1$
     String ATTR_FTDI_DEVICE = LAUNCH_ID + ".ftdi_device"; //$NON-NLS-1$
     String ATTR_FTDI_CORE = LAUNCH_ID + ".ftdi_core"; //$NON-NLS-1$
 
@@ -71,7 +72,7 @@ public interface LaunchConfigurationConstants {
 
     // Default option values
     static final String DEFAULT_OPENOCD_PORT = "49105";
-    static final String DEFAULT_OPELLAXD_PORT = "49105";
+    static final String DEFAULT_ASHLING_PORT = "49105";
     static final String DEFAULT_NSIM_PORT = "49105";
     static final String DEFAULT_GDB_HOST = "localhost";
     static final String DEFAULT_OPENOCD_BIN_PATH_LINUX = "/usr/local/bin/openocd";
@@ -84,8 +85,6 @@ public interface LaunchConfigurationConstants {
     // Ashling
     static final String ASHLING_DEFAULT_PATH_WINDOWS = "C:\\AshlingOpellaXDforARC\\ash-arc-gdb-server.exe";
     static final String ASHLING_DEFAULT_PATH_LINUX = "/usr/bin/ash-arc-gdb-server";
-    static final String ASHLING_DEFAULT_XML_FILE = "arc-em-cpu.xml";
-    static final String ASHLING_DEFAULT_TDESC_FILE = "opella-arcem-tdesc.xml";
 
     //Custom Gdbserver
     String ATTR_DEBUGGER_CUSTOM_GDBSERVER_BIN_PATH =  LAUNCH_ID + ".debugger_custom_gdbsever_bin_path";

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/LaunchConfigurationConstants.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/LaunchConfigurationConstants.java
@@ -71,8 +71,8 @@ public interface LaunchConfigurationConstants {
     static final int CURRENT_FILE_FORMAT_VERSION = 2;
 
     // Default option values
+    static final String DEFAULT_GDBSERVER_PORT = "49105";
     static final String DEFAULT_OPENOCD_PORT = "49105";
-    static final String DEFAULT_ASHLING_PORT = "49105";
     static final String DEFAULT_NSIM_PORT = "49105";
     static final String DEFAULT_GDB_HOST = "localhost";
     static final String DEFAULT_OPENOCD_BIN_PATH_LINUX = "/usr/local/bin/openocd";

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/ArcGdbServer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/common/ArcGdbServer.java
@@ -12,7 +12,8 @@ package com.arc.embeddedcdt.common;
 
 public enum ArcGdbServer {
     JTAG_OPENOCD("JTAG via OpenOCD"),
-    JTAG_ASHLING("JTAG via Opella-XD"),
+    JTAG_ASHLING_OPELLAXD("JTAG via Ashling Opella-XD"),
+    JTAG_ASHLING_VITRAXS("JTAG via Ashling Vitra-XS"),
     NSIM("nSIM"),
     GENERIC_GDBSERVER("Connect to running GDB server"),
     CUSTOM_GDBSERVER("Custom GDB server");

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/ArcDebugServicesFactory.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/ArcDebugServicesFactory.java
@@ -53,7 +53,8 @@ public class ArcDebugServicesFactory extends GdbDebugServicesFactory {
         switch (gdbServer) {
         case JTAG_OPENOCD:
             return new OpenOcdBackend(session, arg);
-        case JTAG_ASHLING:
+        case JTAG_ASHLING_OPELLAXD:
+        case JTAG_ASHLING_VITRAXS:
             return new AshlingBackend(session, arg);
         case NSIM:
             return new NsimBackend(session, arg);

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/gdb/server/AshlingBackend.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/gdb/server/AshlingBackend.java
@@ -15,6 +15,7 @@ import java.io.File;
 import org.eclipse.cdt.dsf.service.DsfSession;
 import org.eclipse.debug.core.ILaunchConfiguration;
 
+import com.arc.embeddedcdt.common.ArcGdbServer;
 import com.arc.embeddedcdt.dsf.GdbServerBackend;
 import com.arc.embeddedcdt.dsf.utils.ConfigurationReader;
 
@@ -22,9 +23,8 @@ public class AshlingBackend extends GdbServerBackend {
 
     private String commandLineTemplate = "%s"
             + " --jtag-frequency %s"
-            + " --device arc"
-            + " --gdb-port %s"
-            + " --arc-reg-file %s";
+            + " --device %s"
+            + " --gdb-port %s";
 
     public AshlingBackend(DsfSession session, ILaunchConfiguration launchConfiguration) {
         super(session, launchConfiguration);
@@ -36,24 +36,33 @@ public class AshlingBackend extends GdbServerBackend {
         ConfigurationReader cfgReader = new ConfigurationReader(launchConfiguration);
         String ashlingPath = cfgReader.getAshlingPath();
         String gdbServerPort = cfgReader.getGdbServerPort();
-        String ashlingXmlFile = cfgReader.getAshlingXmlPath();
         String jtagFrequency = cfgReader.getAshlingJtagFrequency();
+        String device = cfgReader.getAshlingDevice();
+        if (device == null || device.isEmpty()) {
+            device = "arc";
+        }
+        String probeSerialNumber = cfgReader.getAshlingProbeSerialNumber();
+        String gdbServerArgs = cfgReader.getAshlingGdbServerArgs();
 
         String commandLine = String.format(commandLineTemplate, ashlingPath, jtagFrequency,
-                gdbServerPort, ashlingXmlFile);
+                device, gdbServerPort);
+        if (cfgReader.getGdbServer() == ArcGdbServer.JTAG_ASHLING_OPELLAXD) {
+            commandLine += " --probe-type opella-xd";
+        } else if (cfgReader.getGdbServer() == ArcGdbServer.JTAG_ASHLING_VITRAXS) {
+            commandLine += " --probe-type vitra-xs";
+        }
+        if (probeSerialNumber != null && !probeSerialNumber.isEmpty()) {
+            commandLine += " --instance " + probeSerialNumber;
+        }
+        if (gdbServerArgs != null && !gdbServerArgs.isEmpty()) {
+            commandLine += " " + gdbServerArgs;
+        }
         return commandLine;
     }
 
     @Override
     public String getProcessLabel() {
         return "Ashling GDBserver";
-    }
-
-    @Override
-    public String getCommandToConnect() {
-        ConfigurationReader cfgReader = new ConfigurationReader(launchConfiguration);
-        return "set tdesc filename " + cfgReader.getAshlingTDescPath() + "\n"
-                + super.getCommandToConnect();
     }
 
     @Override

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/ConfigurationReader.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/ConfigurationReader.java
@@ -100,8 +100,9 @@ public class ConfigurationReader {
       case JTAG_OPENOCD:
         defaultValue = LaunchConfigurationConstants.DEFAULT_OPENOCD_PORT;
         break;
-      case JTAG_ASHLING:
-        defaultValue = LaunchConfigurationConstants.DEFAULT_OPELLAXD_PORT;
+      case JTAG_ASHLING_OPELLAXD:
+      case JTAG_ASHLING_VITRAXS:
+        defaultValue = LaunchConfigurationConstants.DEFAULT_ASHLING_PORT;
         break;
       case NSIM:
         defaultValue = LaunchConfigurationConstants.DEFAULT_NSIM_PORT;
@@ -196,16 +197,20 @@ public class ConfigurationReader {
         defaultValue);
   }
 
-  public String getAshlingXmlPath() {
-    return getAttribute(LaunchConfigurationConstants.ATTR_ASHLING_XML_PATH, "");
-  }
-
-  public String getAshlingTDescPath() {
-    return getAttribute(LaunchConfigurationConstants.ATTR_ASHLING_TDESC_PATH, "");
-  }
-
   public String getAshlingJtagFrequency() {
     return getAttribute(LaunchConfigurationConstants.ATTR_JTAG_FREQUENCY, "");
+  }
+
+  public String getAshlingDevice() {
+    return getAttribute(LaunchConfigurationConstants.ATTR_ASHLING_DEVICE, "");
+  }
+
+  public String getAshlingProbeSerialNumber() {
+    return getAttribute(LaunchConfigurationConstants.ATTR_ASHLING_PROBE_SERIAL_NUMBER, "");
+  }
+
+  public String getAshlingGdbServerArgs() {
+    return getAttribute(LaunchConfigurationConstants.ATTR_ASHLING_GDBSERVER_ARGS, "");
   }
 
   public String getCustomGdbServerPath() {

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/ConfigurationReader.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/ConfigurationReader.java
@@ -102,7 +102,7 @@ public class ConfigurationReader {
         break;
       case JTAG_ASHLING_OPELLAXD:
       case JTAG_ASHLING_VITRAXS:
-        defaultValue = LaunchConfigurationConstants.DEFAULT_ASHLING_PORT;
+        defaultValue = LaunchConfigurationConstants.DEFAULT_GDBSERVER_PORT;
         break;
       case NSIM:
         defaultValue = LaunchConfigurationConstants.DEFAULT_NSIM_PORT;

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/ConfigurationWriter.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/dsf/utils/ConfigurationWriter.java
@@ -148,16 +148,20 @@ public class ConfigurationWriter {
     setAttribute(LaunchConfigurationConstants.ATTR_DEBUGGER_EXTERNAL_TOOLS_ASHLING_PATH, value);
   }
 
-  public void setAshlingXmlPath(final String value) {
-    setAttribute(LaunchConfigurationConstants.ATTR_ASHLING_XML_PATH, value);
-  }
-
-  public void setAshlingTDescPath(final String value) {
-    setAttribute(LaunchConfigurationConstants.ATTR_ASHLING_TDESC_PATH, value);
-  }
-
   public void setAshlingJtagFrequency(final String value) {
     setAttribute(LaunchConfigurationConstants.ATTR_JTAG_FREQUENCY, value);
+  }
+
+  public void setAshlingDevice(final String value) {
+    setAttribute(LaunchConfigurationConstants.ATTR_ASHLING_DEVICE, value);
+  }
+
+  public void setAshlingProbeSerialNumber(final String value) {
+    setAttribute(LaunchConfigurationConstants.ATTR_ASHLING_PROBE_SERIAL_NUMBER, value);
+  }
+
+  public void setAshlingGdbServerArgs(final String value) {
+    setAttribute(LaunchConfigurationConstants.ATTR_ASHLING_GDBSERVER_ARGS, value);
   }
 
   public void setCustomGdbServerPath(final String value) {

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/ARCTerminalTab.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/ARCTerminalTab.java
@@ -178,7 +178,8 @@ public class ARCTerminalTab extends CLaunchConfigurationTab {
         fLaunchComButton.setSelection(fLaunchTerminal);
 
         gdbServer = cfgReader.getGdbServer();
-        if (gdbServer == ArcGdbServer.JTAG_OPENOCD || gdbServer == ArcGdbServer.JTAG_ASHLING) {
+        if (gdbServer == ArcGdbServer.JTAG_OPENOCD || gdbServer == ArcGdbServer.JTAG_ASHLING_OPELLAXD
+                || gdbServer == ArcGdbServer.JTAG_ASHLING_VITRAXS) {
             if (!comPort.equalsIgnoreCase("")) {
                 // One of the items in the list of COM ports becomes blank
                 // sometimes, if comPort is removed directly instead

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
@@ -66,9 +66,10 @@ public class DebuggerGroupContainer extends Observable{
   private Combo externalToolsCombo;
   private ArcGdbServer gdbServer = ArcGdbServer.DEFAULT_GDB_SERVER;
   private Spinner jitThreadSpinner;
-  private FileFieldEditor ashlingXmlPathEditor;
-  private FileFieldEditor ashlingTdescXmlPathEditor;
   private FileFieldEditor ashlingBinaryPathEditor;
+  private Text ashlingDeviceText;
+  private Text ashlingProbeSerialNumberText;
+  private Text ashlingGdbServerArgsText;
   private FileFieldEditor customGdbBinaryPathEditor;
   private FileFieldEditor openOcdBinaryPathEditor;
   private FileFieldEditor openOcdConfigurationPathEditor;
@@ -96,8 +97,9 @@ public class DebuggerGroupContainer extends Observable{
   private String jitThread = "1";
   private String nsimTcfFilesLast = "";
   private String nsimPropertiesFilesLast = "";
-  private String ashlingTdescPath = "";
-  private String ashlingXmlPath = "";
+  private String ashlingDevice = "";
+  private String ashlingProbeSerialNumber = "";
+  private String ashlingGdbServerArgs = "";
   private String externalToolsAshlingPath = "";
   private String customGdbPath;
   private String openOcdBinaryPath;
@@ -185,14 +187,6 @@ public class DebuggerGroupContainer extends Observable{
       gdbServerPortNumberText.setText(portNumber);
   }
 
-  public FileFieldEditor getAshlingTdescXmlPathEditor(){
-    return ashlingTdescXmlPathEditor;
-  }
-
-  public FileFieldEditor getAshlingXmlPathEditor(){
-    return ashlingXmlPathEditor;
-  }
-
   public FileFieldEditor getAshlingBinaryPathEditor(){
     return ashlingBinaryPathEditor;
   }
@@ -235,14 +229,9 @@ public class DebuggerGroupContainer extends Observable{
             : LaunchConfigurationConstants.ASHLING_DEFAULT_PATH_LINUX;
     externalToolsAshlingPath = configurationReader.getOrDefault(defaultAshlingPath, "",
         configurationReader.getAshlingPath());
-    String ashlingXmlFile = new File(defaultAshlingPath).getParentFile().getPath()
-        + java.io.File.separator + LaunchConfigurationConstants.ASHLING_DEFAULT_XML_FILE;
-    ashlingXmlPath = configurationReader.getOrDefault(ashlingXmlFile, "",
-        configurationReader.getAshlingXmlPath());
-    String defaultTDescPath = new File(defaultAshlingPath).getParentFile().getPath()
-        + java.io.File.separator + LaunchConfigurationConstants.ASHLING_DEFAULT_TDESC_FILE;
-    ashlingTdescPath = configurationReader.getOrDefault(defaultTDescPath, "",
-        configurationReader.getAshlingTDescPath());
+    ashlingDevice = configurationReader.getAshlingDevice();
+    ashlingProbeSerialNumber = configurationReader.getAshlingProbeSerialNumber();
+    ashlingGdbServerArgs = configurationReader.getAshlingGdbServerArgs();
     externalToolsNsimPath = configurationReader.getOrDefault(
         getNsimdrvDefaultPath(), "", configurationReader.getNsimPath());
     customGdbPath = configurationReader.getCustomGdbServerPath();
@@ -303,24 +292,77 @@ public class DebuggerGroupContainer extends Observable{
             GridData.FILL_BOTH);
 
     createAshlingBinaryPathEditor(compositeCom);
-    createAshlingXmlPathEditor(compositeCom);
-    createAshlingTdescXmlPathEditor(compositeCom);
+    createAshlingDeviceAndProbeFields(compositeCom);
     createJtagFrequencyCombo(compositeCom);
+    createAshlingGdbServerArgsField(compositeCom);
   }
 
-  private void createAshlingXmlPathEditor(Composite compositeCom){
-    // Path to Ashling XMl file
-    ashlingXmlPathEditor = new FileFieldEditor("ashlingXmlPathEditor", "Ashling XML File", false,
-            StringButtonFieldEditor.VALIDATE_ON_KEY_STROKE, compositeCom);
-    ashlingXmlPathEditor.setStringValue(ashlingXmlPath);
+  private void createAshlingGdbServerArgsField(Composite compositeCom) {
+    Label label = new Label(compositeCom, SWT.LEFT);
+    label.setText("GDBServer arguments:");
+    ashlingGdbServerArgsText = new Text(compositeCom, SWT.MULTI | SWT.BORDER | SWT.WRAP | SWT.V_SCROLL);
+    GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
+    gridData.horizontalSpan = 2;
+    gridData.heightHint = 60;
+    ashlingGdbServerArgsText.setLayoutData(gridData);
+    if (!ashlingGdbServerArgs.isEmpty())
+      ashlingGdbServerArgsText.setText(ashlingGdbServerArgs);
+    ashlingGdbServerArgsText.addModifyListener(new ModifyListener() {
+      public void modifyText(ModifyEvent event) {
+        ashlingGdbServerArgs = ashlingGdbServerArgsText.getText();
+        sendNotification(null);
+      }
+    });
+  }
 
-    ashlingXmlPathEditor.setPropertyChangeListener(new IPropertyChangeListener() {
-        public void propertyChange(PropertyChangeEvent event) {
-            if (event.getProperty() == "field_editor_value") {
-                ashlingXmlPath = (String) event.getNewValue();
-                sendNotification(null);
-            }
-        }
+  private void createAshlingDeviceAndProbeFields(Composite compositeCom) {
+    // Span all 3 parent columns with a sub-composite so neither DeviceText nor
+    // ProbeText is placed in col 3 (the Browse-button column) of the parent grid.
+    Composite rowComposite = new Composite(compositeCom, SWT.NONE);
+    GridLayout rowLayout = new GridLayout(4, false);
+    rowLayout.marginWidth = 0;
+    rowLayout.marginHeight = 0;
+    rowComposite.setLayout(rowLayout);
+    GridData rowData = new GridData(GridData.FILL_HORIZONTAL);
+    rowData.horizontalSpan = 3;
+    rowComposite.setLayoutData(rowData);
+
+    Label deviceLabel = new Label(rowComposite, SWT.LEFT);
+    deviceLabel.setText("Device:");
+    GridData deviceLabelGridData = new GridData(GridData.BEGINNING);
+    deviceLabelGridData.widthHint = 134;
+    deviceLabel.setLayoutData(deviceLabelGridData);
+    ashlingDeviceText = new Text(rowComposite, SWT.SINGLE | SWT.BORDER | SWT.BEGINNING);
+    ashlingDeviceText.setToolTipText(
+        "Run ash-arc-gdb-server.exe --help to view the list of supported devices.");
+    GridData deviceGridData = new GridData(GridData.BEGINNING);
+    deviceGridData.widthHint = 115;
+    ashlingDeviceText.setLayoutData(deviceGridData);
+    if (!ashlingDevice.isEmpty())
+      ashlingDeviceText.setText(ashlingDevice);
+    ashlingDeviceText.addModifyListener(new ModifyListener() {
+      public void modifyText(ModifyEvent event) {
+        ashlingDevice = ashlingDeviceText.getText();
+        sendNotification(null);
+      }
+    });
+
+    Label probeLabel = new Label(rowComposite, SWT.LEFT);
+    probeLabel.setText("Probe serial number:");
+    GridData probeLabelGridData = new GridData(GridData.BEGINNING);
+    probeLabelGridData.horizontalIndent = 75;
+    probeLabel.setLayoutData(probeLabelGridData);
+    ashlingProbeSerialNumberText = new Text(rowComposite, SWT.SINGLE | SWT.BORDER | SWT.BEGINNING);
+    GridData probeGridData = new GridData(GridData.BEGINNING);
+    probeGridData.widthHint = 115;
+    ashlingProbeSerialNumberText.setLayoutData(probeGridData);
+    if (!ashlingProbeSerialNumber.isEmpty())
+      ashlingProbeSerialNumberText.setText(ashlingProbeSerialNumber);
+    ashlingProbeSerialNumberText.addModifyListener(new ModifyListener() {
+      public void modifyText(ModifyEvent event) {
+        ashlingProbeSerialNumber = ashlingProbeSerialNumberText.getText();
+        sendNotification(null);
+      }
     });
   }
 
@@ -353,13 +395,12 @@ public class DebuggerGroupContainer extends Observable{
             }
           }
           break;
-        case JTAG_ASHLING:
+        case JTAG_ASHLING_OPELLAXD:
+        case JTAG_ASHLING_VITRAXS:
           if (groupComAshling.isDisposed()) {
             return true;
           }
-          if (!isValidFileFieldEditor(ashlingBinaryPathEditor)
-              || !isValidFileFieldEditor(ashlingXmlPathEditor)
-              || !isValidFileFieldEditor(ashlingTdescXmlPathEditor)) {
+          if (!isValidFileFieldEditor(ashlingBinaryPathEditor)) {
             return false;
           }
           break;
@@ -704,8 +745,31 @@ public class DebuggerGroupContainer extends Observable{
                 groupCom.setVisible(true);
                 createTabItemGenericGdbServer = false;
                 createTabItemCustomGdb = false;
-            } else if (gdbServer == ArcGdbServer.JTAG_ASHLING) {
-                setPortNumberText(LaunchConfigurationConstants.DEFAULT_OPELLAXD_PORT);
+            } else if (gdbServer == ArcGdbServer.JTAG_ASHLING_OPELLAXD) {
+                setPortNumberText(LaunchConfigurationConstants.DEFAULT_ASHLING_PORT);
+
+                groupNsim.dispose();
+                if (groupGenericGdbServer != null) {
+                    groupGenericGdbServer.dispose();
+                }
+                groupCom.dispose();
+                groupComCustomGdb.dispose();
+                createTabItemNsim = false;
+                createTabItemGenericGdbServer = false;
+                createTabItemCom = false;
+                createTabItemCustomGdb = false;
+
+                if (!createTabItemComAshling) {
+                    if (!groupComAshling.isDisposed())
+                        groupComAshling.dispose();
+
+                    createTabItemComAshling(subComp);
+                }
+
+                groupComAshling.setText(gdbServer.toString());
+                groupComAshling.setVisible(true);
+            } else if (gdbServer == ArcGdbServer.JTAG_ASHLING_VITRAXS) {
+                setPortNumberText(LaunchConfigurationConstants.DEFAULT_ASHLING_PORT);
 
                 groupNsim.dispose();
                 if (groupGenericGdbServer != null) {
@@ -827,7 +891,7 @@ public class DebuggerGroupContainer extends Observable{
                 }
 
             } else if (gdbServer == ArcGdbServer.CUSTOM_GDBSERVER) {
-                setPortNumberText(LaunchConfigurationConstants.DEFAULT_OPELLAXD_PORT);
+                setPortNumberText(LaunchConfigurationConstants.DEFAULT_ASHLING_PORT);
 
                 groupNsim.dispose();
                 groupCom.dispose();
@@ -849,7 +913,7 @@ public class DebuggerGroupContainer extends Observable{
                     groupComCustomGdb.setVisible(true);
             }
 
-            subComp.layout();
+            subComp.layout(true, true);
             sendNotification(null);
         }
     });
@@ -1122,7 +1186,7 @@ public class DebuggerGroupContainer extends Observable{
 
   public void createAshlingBinaryPathEditor(Composite compositeCom){
     // Path to Ashling binary
-    ashlingBinaryPathEditor = new FileFieldEditor("ashlingBinaryPath", "Ashling binary path", false,
+    ashlingBinaryPathEditor = new FileFieldEditor("ashlingBinaryPath", "Ashling GDB Server path:", false,
             StringButtonFieldEditor.VALIDATE_ON_KEY_STROKE, compositeCom);
     ashlingBinaryPathEditor.setStringValue(externalToolsAshlingPath);
 
@@ -1172,24 +1236,6 @@ public class DebuggerGroupContainer extends Observable{
     });
   }
 
-  public void createAshlingTdescXmlPathEditor(Composite compositeCom){
-    // Path to ashling target description file
-    ashlingTdescXmlPathEditor = new FileFieldEditor("ashlingTdescXmlPath",
-            "Target description XML file", false,
-            StringButtonFieldEditor.VALIDATE_ON_KEY_STROKE, compositeCom);
-    ashlingTdescXmlPathEditor.setStringValue(ashlingTdescPath);
-
-    ashlingTdescXmlPathEditor.setPropertyChangeListener(new IPropertyChangeListener() {
-        public void propertyChange(PropertyChangeEvent event) {
-            if (event.getProperty() == "field_editor_value") {
-                ashlingTdescPath = (String) event.getNewValue();
-                setChanged();
-                notifyObservers();
-            }
-        }
-    });
-  }
-
   public boolean isJtagFrequencyComboDisposed(){
     return jtagFrequencyCombo.isDisposed();
   }
@@ -1226,8 +1272,9 @@ public class DebuggerGroupContainer extends Observable{
     configurationWriter.setOpenOcdConfig(openOcdConfigurationPath);
     configurationWriter.setOpenOcdPath(openOcdBinaryPath);
     configurationWriter.setAshlingPath(externalToolsAshlingPath);
-    configurationWriter.setAshlingXmlPath(ashlingXmlPath);
-    configurationWriter.setAshlingTDescPath(ashlingTdescPath);
+    configurationWriter.setAshlingDevice(ashlingDevice);
+    configurationWriter.setAshlingProbeSerialNumber(ashlingProbeSerialNumber);
+    configurationWriter.setAshlingGdbServerArgs(ashlingGdbServerArgs);
     configurationWriter.setNsimPath(externalToolsNsimPath);
     configurationWriter.setCustomGdbServerPath(customGdbPath);
     if (customGdbCommandLineArguments != null)
@@ -1342,10 +1389,14 @@ public class DebuggerGroupContainer extends Observable{
   public void createJtagFrequencyCombo(Composite composite) {
     Label label = new Label(composite, SWT.LEFT);
     label.setText("JTAG frequency:");
+    GridData jtagLabelGridData = new GridData(GridData.BEGINNING);
+    jtagLabelGridData.widthHint = 110;
+    label.setLayoutData(jtagLabelGridData);
     jtagFrequencyCombo = new Combo(composite, SWT.None);// 1-2 and 1-3
 
     GridData gridDataJtag = new GridData(GridData.BEGINNING);
     gridDataJtag.widthHint = 100;
+    gridDataJtag.horizontalSpan = 2;
     jtagFrequencyCombo.setLayoutData(gridDataJtag);
 
     jtagFrequencyCombo.add("100MHz");
@@ -1494,13 +1545,8 @@ public class DebuggerGroupContainer extends Observable{
         isWindowsOs() ? LaunchConfigurationConstants.ASHLING_DEFAULT_PATH_WINDOWS
             : LaunchConfigurationConstants.ASHLING_DEFAULT_PATH_LINUX;
     configurationWriter.setAshlingPath(defaultAshlingPath);
-
-    String ashlingXmlFile = new File(defaultAshlingPath).getParentFile().getPath()
-        + java.io.File.separator +  LaunchConfigurationConstants.ASHLING_DEFAULT_XML_FILE;
-    configurationWriter.setAshlingXmlPath(ashlingXmlFile);
-
-    String defaultTDescPath = new File(defaultAshlingPath).getParentFile().getPath()
-        + java.io.File.separator + LaunchConfigurationConstants.ASHLING_DEFAULT_TDESC_FILE;
-    configurationWriter.setAshlingTDescPath(defaultTDescPath);
+    configurationWriter.setAshlingDevice("");
+    configurationWriter.setAshlingProbeSerialNumber("");
+    configurationWriter.setAshlingGdbServerArgs("");
   }
 }

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
@@ -748,7 +748,7 @@ public class DebuggerGroupContainer extends Observable{
                 createTabItemGenericGdbServer = false;
                 createTabItemCustomGdb = false;
             } else if (gdbServer == ArcGdbServer.JTAG_ASHLING_OPELLAXD) {
-                setPortNumberText(LaunchConfigurationConstants.DEFAULT_ASHLING_PORT);
+                setPortNumberText(LaunchConfigurationConstants.DEFAULT_GDBSERVER_PORT);
 
                 groupNsim.dispose();
                 if (groupGenericGdbServer != null) {
@@ -771,7 +771,7 @@ public class DebuggerGroupContainer extends Observable{
                 groupComAshling.setText(gdbServer.toString());
                 groupComAshling.setVisible(true);
             } else if (gdbServer == ArcGdbServer.JTAG_ASHLING_VITRAXS) {
-                setPortNumberText(LaunchConfigurationConstants.DEFAULT_ASHLING_PORT);
+                setPortNumberText(LaunchConfigurationConstants.DEFAULT_GDBSERVER_PORT);
 
                 groupNsim.dispose();
                 if (groupGenericGdbServer != null) {
@@ -893,7 +893,7 @@ public class DebuggerGroupContainer extends Observable{
                 }
 
             } else if (gdbServer == ArcGdbServer.CUSTOM_GDBSERVER) {
-                setPortNumberText(LaunchConfigurationConstants.DEFAULT_ASHLING_PORT);
+                setPortNumberText(LaunchConfigurationConstants.DEFAULT_GDBSERVER_PORT);
 
                 groupNsim.dispose();
                 groupCom.dispose();

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
@@ -316,27 +316,28 @@ public class DebuggerGroupContainer extends Observable{
   }
 
   private void createAshlingDeviceAndProbeFields(Composite compositeCom) {
-    // Span all 3 parent columns with a sub-composite so neither DeviceText nor
-    // ProbeText is placed in col 3 (the Browse-button column) of the parent grid.
+    // Device label in col1 — aligns with JTAG frequency label
+    Label deviceLabel = new Label(compositeCom, SWT.LEFT);
+    deviceLabel.setText("Device:");
+    GridData deviceLabelGridData = new GridData(GridData.BEGINNING);
+    deviceLabelGridData.widthHint = 110;
+    deviceLabel.setLayoutData(deviceLabelGridData);
+
+    // Sub-composite in col2+col3 holds Device text + Probe label + Probe text in one row
     Composite rowComposite = new Composite(compositeCom, SWT.NONE);
     GridLayout rowLayout = new GridLayout(4, false);
     rowLayout.marginWidth = 0;
     rowLayout.marginHeight = 0;
     rowComposite.setLayout(rowLayout);
     GridData rowData = new GridData(GridData.FILL_HORIZONTAL);
-    rowData.horizontalSpan = 3;
+    rowData.horizontalSpan = 2;
     rowComposite.setLayoutData(rowData);
 
-    Label deviceLabel = new Label(rowComposite, SWT.LEFT);
-    deviceLabel.setText("Device:");
-    GridData deviceLabelGridData = new GridData(GridData.BEGINNING);
-    deviceLabelGridData.widthHint = 134;
-    deviceLabel.setLayoutData(deviceLabelGridData);
     ashlingDeviceText = new Text(rowComposite, SWT.SINGLE | SWT.BORDER | SWT.BEGINNING);
     ashlingDeviceText.setToolTipText(
         "Run ash-arc-gdb-server --help to view the list of supported devices.");
     GridData deviceGridData = new GridData(GridData.BEGINNING);
-    deviceGridData.widthHint = 115;
+    deviceGridData.widthHint = 120;
     ashlingDeviceText.setLayoutData(deviceGridData);
     if (!ashlingDevice.isEmpty())
       ashlingDeviceText.setText(ashlingDevice);
@@ -350,7 +351,7 @@ public class DebuggerGroupContainer extends Observable{
     Label probeLabel = new Label(rowComposite, SWT.LEFT);
     probeLabel.setText("Probe serial number:");
     GridData probeLabelGridData = new GridData(GridData.BEGINNING);
-    probeLabelGridData.horizontalIndent = 75;
+    probeLabelGridData.horizontalIndent = 100;
     probeLabel.setLayoutData(probeLabelGridData);
     ashlingProbeSerialNumberText = new Text(rowComposite, SWT.SINGLE | SWT.BORDER | SWT.BEGINNING);
     GridData probeGridData = new GridData(GridData.BEGINNING);
@@ -703,11 +704,12 @@ public class DebuggerGroupContainer extends Observable{
     Label label = new Label(subComp, SWT.LEFT);
     label.setText("ARC GDB Server:");
     GridData gd = new GridData();
+    gd.widthHint = 130;
     label.setLayoutData(gd);
 
-    GridData serverTypeComboGridData = new GridData(SWT.BEGINNING, SWT.BEGINNING, true, false);
+    GridData serverTypeComboGridData = new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false);
     serverTypeComboGridData.horizontalSpan = 4;
-    serverTypeComboGridData.minimumWidth = minTextWidth;
+    serverTypeComboGridData.widthHint = minTextWidth;
     externalToolsCombo = new Combo(subComp, SWT.None | SWT.READ_ONLY);
     externalToolsCombo.setLayoutData(serverTypeComboGridData);
     for (ArcGdbServer server: ArcGdbServer.values()) {
@@ -923,6 +925,7 @@ public class DebuggerGroupContainer extends Observable{
     label.setText(Messages.Port_number_textfield_label);
     GridData gdbPortLabelGridData = new GridData();
     gdbPortLabelGridData.horizontalSpan = 1;
+    gdbPortLabelGridData.widthHint = 130;
     label.setLayoutData(gdbPortLabelGridData);
 
     createGdbServerPortNumberText(subComp, minTextWidth);
@@ -1173,9 +1176,9 @@ public class DebuggerGroupContainer extends Observable{
   public void createGdbServerPortNumberText(Composite subComp, int minTextWidth){
     // GDB port text field
     gdbServerPortNumberText = new Text(subComp, SWT.SINGLE | SWT.BORDER | SWT.BEGINNING);
-    GridData gdbPortTextGridData = new GridData(SWT.BEGINNING, SWT.BEGINNING, true, false);
+    GridData gdbPortTextGridData = new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false);
     gdbPortTextGridData.horizontalSpan = 4;
-    gdbPortTextGridData.minimumWidth = minTextWidth;
+    gdbPortTextGridData.widthHint = minTextWidth + 17;
     gdbServerPortNumberText.setLayoutData(gdbPortTextGridData);
     gdbServerPortNumberText.addModifyListener(new ModifyListener() {
         public void modifyText(ModifyEvent event) {

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/DebuggerGroupContainer.java
@@ -334,7 +334,7 @@ public class DebuggerGroupContainer extends Observable{
     deviceLabel.setLayoutData(deviceLabelGridData);
     ashlingDeviceText = new Text(rowComposite, SWT.SINGLE | SWT.BORDER | SWT.BEGINNING);
     ashlingDeviceText.setToolTipText(
-        "Run ash-arc-gdb-server.exe --help to view the list of supported devices.");
+        "Run ash-arc-gdb-server --help to view the list of supported devices.");
     GridData deviceGridData = new GridData(GridData.BEGINNING);
     deviceGridData.widthHint = 115;
     ashlingDeviceText.setLayoutData(deviceGridData);

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/FirstlaunchDialog.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/gui/FirstlaunchDialog.java
@@ -60,7 +60,8 @@ public class FirstlaunchDialog extends Dialog {
 
         Combo fPrgmArgumentsComboInit = new Combo(shell, SWT.SINGLE | SWT.BORDER);
         fPrgmArgumentsComboInit.add(ArcGdbServer.JTAG_OPENOCD.toString());
-        fPrgmArgumentsComboInit.add(ArcGdbServer.JTAG_ASHLING.toString());
+        fPrgmArgumentsComboInit.add(ArcGdbServer.JTAG_ASHLING_OPELLAXD.toString());
+        fPrgmArgumentsComboInit.add(ArcGdbServer.JTAG_ASHLING_VITRAXS.toString());
         fPrgmArgumentsComboInit.add(ArcGdbServer.NSIM.toString());
 
         fPrgmArgumentsLabelCom = new Label(shell, SWT.NULL);

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/launch/LaunchShortcut.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/launch/LaunchShortcut.java
@@ -94,12 +94,12 @@ public class LaunchShortcut extends CApplicationLaunchShortcut implements ILaunc
 
                 switch (gdbServer) {
                 case JTAG_ASHLING_OPELLAXD:
-                    gdbserver_port = LaunchConfigurationConstants.DEFAULT_ASHLING_PORT;
+                    gdbserver_port = LaunchConfigurationConstants.DEFAULT_GDBSERVER_PORT;
                     wc.setAttribute(LaunchConfigurationConstants.ATTR_DEBUGGER_COM_PORT,
                             FirstlaunchDialog.value[1]);
                     break;
                 case JTAG_ASHLING_VITRAXS:
-                    gdbserver_port = LaunchConfigurationConstants.DEFAULT_ASHLING_PORT;
+                    gdbserver_port = LaunchConfigurationConstants.DEFAULT_GDBSERVER_PORT;
                     wc.setAttribute(LaunchConfigurationConstants.ATTR_DEBUGGER_COM_PORT,
                             FirstlaunchDialog.value[1]);
                     break;

--- a/com.arc.embeddedcdt/src/com/arc/embeddedcdt/launch/LaunchShortcut.java
+++ b/com.arc.embeddedcdt/src/com/arc/embeddedcdt/launch/LaunchShortcut.java
@@ -93,8 +93,13 @@ public class LaunchShortcut extends CApplicationLaunchShortcut implements ILaunc
                 String gdbserver_port = "";
 
                 switch (gdbServer) {
-                case JTAG_ASHLING:
-                    gdbserver_port = LaunchConfigurationConstants.DEFAULT_OPELLAXD_PORT;
+                case JTAG_ASHLING_OPELLAXD:
+                    gdbserver_port = LaunchConfigurationConstants.DEFAULT_ASHLING_PORT;
+                    wc.setAttribute(LaunchConfigurationConstants.ATTR_DEBUGGER_COM_PORT,
+                            FirstlaunchDialog.value[1]);
+                    break;
+                case JTAG_ASHLING_VITRAXS:
+                    gdbserver_port = LaunchConfigurationConstants.DEFAULT_ASHLING_PORT;
                     wc.setAttribute(LaunchConfigurationConstants.ATTR_DEBUGGER_COM_PORT,
                             FirstlaunchDialog.value[1]);
                     break;


### PR DESCRIPTION
## Ashling Opella-XD and Vitra-XS Probe Support for ARC Debugging

### Summary
Adds support for **two Ashling JTAG probes: Opella-XD and Vitra-XS** in the ARC GNU Eclipse debugger plug-in. The launch configuration now exposes them as separate GDB-server options and forwards the relevant command-line arguments to `ash-arc-gdb-server`.

### User-visible changes
- New entries in the GDB Server dropdown:
  - *JTAG via Ashling Opella-XD*
  - *JTAG via Ashling Vitra-XS*
- Renamed **Ashling binary path** → **Ashling GDB Server path**.
- Three new fields on the Ashling debugger tab:
  - **Device** — passed as `--device <value>`.
  - **Probe serial number** — passed as `--instance <serial>` . Required when multiple Ashling probes are connected to the host, so the correct probe is selected deterministically.
  - **GDB Server arguments** — multi-line text box whose contents are appended to the ash-arc-gdb-server command line. Let users pass any additional/advanced flags supported by the server without requiring a UI change for each one.
  - Removed **Ashling XML File**  and **Target description XML file**  fields, their corresponding launch configuration attributes and related changes

### Others
Existing launch configurations that stored the legacy `ATTR_ASHLING_XML_PATH` / `ATTR_ASHLING_TDESC_PATH` attributes will no longer read those values; the corresponding flags are no longer passed to the server. No migration is required since the server accepts the new minimal command line.